### PR TITLE
Add file listing razor page

### DIFF
--- a/BlazorIW.Client/Layout/NavMenu.razor
+++ b/BlazorIW.Client/Layout/NavMenu.razor
@@ -31,6 +31,12 @@
         </div>
 
         <div class="nav-item px-3">
+            <NavLink class="nav-link" href="files">
+                <span class="bi bi-folder-nav-menu" aria-hidden="true"></span> File List
+            </NavLink>
+        </div>
+
+        <div class="nav-item px-3">
             <NavLink class="nav-link" href="auth">
                 <span class="bi bi-lock-nav-menu" aria-hidden="true"></span> Auth Required
             </NavLink>

--- a/BlazorIW/Components/Pages/FileList.razor
+++ b/BlazorIW/Components/Pages/FileList.razor
@@ -1,0 +1,54 @@
+@page "/files"
+@using Microsoft.Extensions.FileProviders
+@using System.IO
+@inject IWebHostEnvironment Env
+
+<PageTitle>File List</PageTitle>
+
+<h1>Files under wwwroot</h1>
+
+@if (fileNames == null)
+{
+    <p>Loading...</p>
+}
+else if (!fileNames.Any())
+{
+    <p>No files found.</p>
+}
+else
+{
+    <ul>
+        @foreach (var file in fileNames)
+        {
+            <li>@file</li>
+        }
+    </ul>
+}
+
+@code {
+    private List<string>? fileNames;
+
+    protected override void OnInitialized()
+    {
+        fileNames = GetFilesRecursive(string.Empty).ToList();
+    }
+
+    private IEnumerable<string> GetFilesRecursive(string path)
+    {
+        foreach (var entry in Env.WebRootFileProvider.GetDirectoryContents(path))
+        {
+            if (entry.IsDirectory)
+            {
+                var subPath = Path.Combine(path, entry.Name);
+                foreach (var nested in GetFilesRecursive(subPath))
+                {
+                    yield return nested;
+                }
+            }
+            else
+            {
+                yield return Path.Combine(path, entry.Name).Replace("\\", "/");
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `/files` razor component for listing files from `wwwroot`
- expose the new page in the navigation menu

## Testing
- `dotnet build BlazorIW.sln -v minimal` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847db98330c83228ea14a1ae015eb31