### PR TITLE
Introduce HtmlContent revisions

### DIFF
--- a/BlazorIW/Data/ApplicationDbContext.cs
+++ b/BlazorIW/Data/ApplicationDbContext.cs
@@ -6,6 +6,12 @@ namespace BlazorIW.Data;
 public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options) : IdentityDbContext<ApplicationUser>(options)
 {
     public DbSet<BackgroundVideo> BackgroundVideos => Set<BackgroundVideo>();
-    public DbSet<HtmlContent> HtmlContents => Set<HtmlContent>();
+    public DbSet<HtmlContentRevision> HtmlContents => Set<HtmlContentRevision>();
     public DbSet<BranchOfficeContent> BranchOfficeContents => Set<BranchOfficeContent>();
+
+    protected override void OnModelCreating(ModelBuilder builder)
+    {
+        base.OnModelCreating(builder);
+        builder.Entity<HtmlContentRevision>().HasKey(h => new { h.Id, h.Revision });
+    }
 }

--- a/BlazorIW/Data/DataSeeder.cs
+++ b/BlazorIW/Data/DataSeeder.cs
@@ -45,8 +45,9 @@ public static class DataSeeder
         if (await db.HtmlContents.AnyAsync(cancellationToken))
             return;
 
-        db.HtmlContents.Add(new HtmlContent
+        db.HtmlContents.Add(new HtmlContentRevision
         {
+            Revision = 1,
             Html = "<p>Hello, world!</p>"
         });
 

--- a/BlazorIW/Data/HtmlContent.cs
+++ b/BlazorIW/Data/HtmlContent.cs
@@ -1,7 +1,12 @@
 namespace BlazorIW.Data;
 
-public class HtmlContent : IContent, IHtmlContent
+public class HtmlContent : IContent
 {
     public Guid Id { get; init; } = Guid.NewGuid();
+}
+
+public class HtmlContentRevision : HtmlContent, IHtmlContent
+{
+    public int Revision { get; set; } = 1;
     public string Html { get; set; } = string.Empty;
 }


### PR DESCRIPTION
## Summary
- extend `HtmlContent` with a revision type `HtmlContentRevision`
- map `HtmlContentRevision` in EF and use a composite key
- seed an initial revision for the demo content

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6847ed0b10f083229964ade1a6ce6ae9