### PR TITLE
Track status for HtmlContent revisions

### DIFF
--- a/BlazorIW/Data/ApplicationDbContext.cs
+++ b/BlazorIW/Data/ApplicationDbContext.cs
@@ -13,5 +13,13 @@ public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options
     {
         base.OnModelCreating(builder);
         builder.Entity<HtmlContentRevision>().HasKey(h => new { h.Id, h.Revision });
+        builder.Entity<HtmlContentRevision>()
+            .HasIndex(h => new { h.Id, h.IsReviewRequested })
+            .IsUnique()
+            .HasFilter("\"IsReviewRequested\" = TRUE");
+        builder.Entity<HtmlContentRevision>()
+            .HasIndex(h => new { h.Id, h.IsPublished })
+            .IsUnique()
+            .HasFilter("\"IsPublished\" = TRUE");
     }
 }

--- a/BlazorIW/Data/DataSeeder.cs
+++ b/BlazorIW/Data/DataSeeder.cs
@@ -48,7 +48,8 @@ public static class DataSeeder
         db.HtmlContents.Add(new HtmlContentRevision
         {
             Revision = 1,
-            Html = "<p>Hello, world!</p>"
+            Html = "<p>Hello, world!</p>",
+            IsPublished = true
         });
 
         await db.SaveChangesAsync(cancellationToken);

--- a/BlazorIW/Data/HtmlContent.cs
+++ b/BlazorIW/Data/HtmlContent.cs
@@ -9,4 +9,6 @@ public class HtmlContentRevision : HtmlContent, IHtmlContent
 {
     public int Revision { get; set; } = 1;
     public string Html { get; set; } = string.Empty;
+    public bool IsReviewRequested { get; set; }
+    public bool IsPublished { get; set; }
 }

--- a/BlazorIW/Data/IHtmlContent.cs
+++ b/BlazorIW/Data/IHtmlContent.cs
@@ -3,4 +3,6 @@ namespace BlazorIW.Data;
 public interface IHtmlContent
 {
     string Html { get; set; }
+    bool IsReviewRequested { get; set; }
+    bool IsPublished { get; set; }
 }

--- a/BlazorIW/Migrations/20250610085536_InitialCreate.Designer.cs
+++ b/BlazorIW/Migrations/20250610085536_InitialCreate.Designer.cs
@@ -140,7 +140,23 @@ namespace BlazorIW.Migrations
                         .IsRequired()
                         .HasColumnType("text");
 
+                    b.Property<bool>("IsReviewRequested")
+                        .HasColumnType("boolean");
+
+                    b.Property<bool>("IsPublished")
+                        .HasColumnType("boolean");
+
                     b.HasKey("Id", "Revision");
+
+                    b.HasIndex("Id")
+                        .IsUnique()
+                        .HasFilter("\"IsReviewRequested\" = TRUE")
+                        .HasDatabaseName("IX_HtmlContents_IsReviewRequested");
+
+                    b.HasIndex("Id")
+                        .IsUnique()
+                        .HasFilter("\"IsPublished\" = TRUE")
+                        .HasDatabaseName("IX_HtmlContents_IsPublished");
 
                     b.ToTable("HtmlContents");
                 });

--- a/BlazorIW/Migrations/20250610085536_InitialCreate.cs
+++ b/BlazorIW/Migrations/20250610085536_InitialCreate.cs
@@ -84,12 +84,28 @@ namespace BlazorIW.Migrations
                 {
                     Id = table.Column<Guid>(type: "uuid", nullable: false),
                     Revision = table.Column<int>(type: "integer", nullable: false),
-                    Html = table.Column<string>(type: "text", nullable: false)
+                    Html = table.Column<string>(type: "text", nullable: false),
+                    IsReviewRequested = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false),
+                    IsPublished = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false)
                 },
                 constraints: table =>
                 {
                     table.PrimaryKey("PK_HtmlContents", x => new { x.Id, x.Revision });
                 });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_HtmlContents_IsReviewRequested",
+                table: "HtmlContents",
+                column: "Id",
+                unique: true,
+                filter: "\"IsReviewRequested\" = TRUE");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_HtmlContents_IsPublished",
+                table: "HtmlContents",
+                column: "Id",
+                unique: true,
+                filter: "\"IsPublished\" = TRUE");
 
             migrationBuilder.CreateTable(
                 name: "AspNetRoleClaims",

--- a/BlazorIW/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/BlazorIW/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -137,7 +137,23 @@ namespace BlazorIW.Migrations
                         .IsRequired()
                         .HasColumnType("text");
 
+                    b.Property<bool>("IsReviewRequested")
+                        .HasColumnType("boolean");
+
+                    b.Property<bool>("IsPublished")
+                        .HasColumnType("boolean");
+
                     b.HasKey("Id", "Revision");
+
+                    b.HasIndex("Id")
+                        .IsUnique()
+                        .HasFilter("\"IsReviewRequested\" = TRUE")
+                        .HasDatabaseName("IX_HtmlContents_IsReviewRequested");
+
+                    b.HasIndex("Id")
+                        .IsUnique()
+                        .HasFilter("\"IsPublished\" = TRUE")
+                        .HasDatabaseName("IX_HtmlContents_IsPublished");
 
                     b.ToTable("HtmlContents");
                 });


### PR DESCRIPTION
## Summary
- record publication and review states on HTML content revisions
- enforce uniqueness for these states through filtered indexes
- seed the initial revision as published

## Testing
- `dotnet build BlazorIW.sln --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847f5d17c9c83228a15b628b7b1233a