### PR TITLE
Add initial HtmlContent workflow tests

### DIFF
--- a/BlazorIW.Tests/BlazorIW.Tests.csproj
+++ b/BlazorIW.Tests/BlazorIW.Tests.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.6.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.6.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.5" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.5" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\BlazorIW\BlazorIW.csproj" />
+  </ItemGroup>
+</Project>

--- a/BlazorIW.Tests/HtmlContentWorkflowTests.cs
+++ b/BlazorIW.Tests/HtmlContentWorkflowTests.cs
@@ -1,0 +1,94 @@
+using System;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using BlazorIW.Data;
+using Xunit;
+
+namespace BlazorIW.Tests;
+
+public class HtmlContentWorkflowTests
+{
+    private static SqliteConnection CreateConnection()
+    {
+        var connection = new SqliteConnection("DataSource=:memory:");
+        connection.Open();
+        return connection;
+    }
+
+    private static ApplicationDbContext CreateContext(SqliteConnection connection)
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseSqlite(connection)
+            .Options;
+        var context = new ApplicationDbContext(options);
+        context.Database.EnsureCreated();
+        return context;
+    }
+
+    [Fact]
+    public void Adding_two_published_revisions_fails()
+    {
+        using var connection = CreateConnection();
+        using var context = CreateContext(connection);
+
+        var id = Guid.NewGuid();
+        context.HtmlContents.Add(new HtmlContentRevision
+        {
+            Id = id,
+            Revision = 1,
+            Html = "A",
+            IsPublished = true
+        });
+        context.SaveChanges();
+
+        context.HtmlContents.Add(new HtmlContentRevision
+        {
+            Id = id,
+            Revision = 2,
+            Html = "B",
+            IsPublished = true
+        });
+
+        Assert.Throws<DbUpdateException>(() => context.SaveChanges());
+    }
+
+    [Fact]
+    public void Review_request_flag_is_unique_per_content()
+    {
+        using var connection = CreateConnection();
+        using var context = CreateContext(connection);
+
+        var id = Guid.NewGuid();
+        context.HtmlContents.Add(new HtmlContentRevision { Id = id, Revision = 1, Html = "R1" });
+        context.SaveChanges();
+
+        var rev2 = new HtmlContentRevision { Id = id, Revision = 2, Html = "R2", IsReviewRequested = true };
+        context.HtmlContents.Add(rev2);
+        context.SaveChanges();
+
+        context.HtmlContents.Add(new HtmlContentRevision { Id = id, Revision = 3, Html = "R3", IsReviewRequested = true });
+
+        Assert.Throws<DbUpdateException>(() => context.SaveChanges());
+    }
+
+    [Fact]
+    public void Can_request_review_after_clearing_previous()
+    {
+        using var connection = CreateConnection();
+        using var context = CreateContext(connection);
+
+        var id = Guid.NewGuid();
+        context.HtmlContents.Add(new HtmlContentRevision { Id = id, Revision = 1, Html = "R1" });
+        var rev2 = new HtmlContentRevision { Id = id, Revision = 2, Html = "R2", IsReviewRequested = true };
+        context.HtmlContents.Add(rev2);
+        context.SaveChanges();
+
+        rev2.IsReviewRequested = false;
+        context.SaveChanges();
+
+        context.HtmlContents.Add(new HtmlContentRevision { Id = id, Revision = 3, Html = "R3", IsReviewRequested = true });
+        context.SaveChanges();
+
+        Assert.Equal(3, context.HtmlContents.CountAsync().Result);
+    }
+}

--- a/BlazorIW.sln
+++ b/BlazorIW.sln
@@ -6,6 +6,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BlazorIW", "BlazorIW\Blazor
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BlazorIW.Client", "BlazorIW.Client\BlazorIW.Client.csproj", "{CDB253F5-E8FB-4D76-85AE-504147624D7F}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BlazorIW.Tests", "BlazorIW.Tests\BlazorIW.Tests.csproj", "{A08809B1-05F8-4048-ACDE-F38B6468872F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -37,10 +39,22 @@ Global
 		{C66B50FC-62B0-4B73-A9AE-62A91C7310FF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C66B50FC-62B0-4B73-A9AE-62A91C7310FF}.Release|Any CPU.Build.0 = Release|Any CPU
 		{C66B50FC-62B0-4B73-A9AE-62A91C7310FF}.Release|x64.ActiveCfg = Release|Any CPU
-		{C66B50FC-62B0-4B73-A9AE-62A91C7310FF}.Release|x64.Build.0 = Release|Any CPU
-		{C66B50FC-62B0-4B73-A9AE-62A91C7310FF}.Release|x86.ActiveCfg = Release|Any CPU
-		{C66B50FC-62B0-4B73-A9AE-62A91C7310FF}.Release|x86.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {C66B50FC-62B0-4B73-A9AE-62A91C7310FF}.Release|x64.Build.0 = Release|Any CPU
+                {C66B50FC-62B0-4B73-A9AE-62A91C7310FF}.Release|x86.ActiveCfg = Release|Any CPU
+                {C66B50FC-62B0-4B73-A9AE-62A91C7310FF}.Release|x86.Build.0 = Release|Any CPU
+                {A08809B1-05F8-4048-ACDE-F38B6468872F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {A08809B1-05F8-4048-ACDE-F38B6468872F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {A08809B1-05F8-4048-ACDE-F38B6468872F}.Debug|x64.ActiveCfg = Debug|Any CPU
+                {A08809B1-05F8-4048-ACDE-F38B6468872F}.Debug|x64.Build.0 = Debug|Any CPU
+                {A08809B1-05F8-4048-ACDE-F38B6468872F}.Debug|x86.ActiveCfg = Debug|Any CPU
+                {A08809B1-05F8-4048-ACDE-F38B6468872F}.Debug|x86.Build.0 = Debug|Any CPU
+                {A08809B1-05F8-4048-ACDE-F38B6468872F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {A08809B1-05F8-4048-ACDE-F38B6468872F}.Release|Any CPU.Build.0 = Release|Any CPU
+                {A08809B1-05F8-4048-ACDE-F38B6468872F}.Release|x64.ActiveCfg = Release|Any CPU
+                {A08809B1-05F8-4048-ACDE-F38B6468872F}.Release|x64.Build.0 = Release|Any CPU
+                {A08809B1-05F8-4048-ACDE-F38B6468872F}.Release|x86.ActiveCfg = Release|Any CPU
+                {A08809B1-05F8-4048-ACDE-F38B6468872F}.Release|x86.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection


### PR DESCRIPTION
## Summary
- set up new xUnit test project
- cover HtmlContent workflow rules using in-memory SQLite

## Testing
- `dotnet test BlazorIW.Tests/BlazorIW.Tests.csproj -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847f9039310832282645605556d0f70