### PR TITLE
Fix HttpClient base address in FileService

### DIFF
--- a/BlazorIW.Client/Services/FileService.cs
+++ b/BlazorIW.Client/Services/FileService.cs
@@ -1,13 +1,20 @@
 using System.Net.Http.Json;
+using Microsoft.AspNetCore.Components;
 
 namespace BlazorIW.Client.Services;
 
-public class FileService(HttpClient httpClient)
+public class FileService(HttpClient httpClient, NavigationManager navigationManager)
 {
     private readonly HttpClient _httpClient = httpClient;
+    private readonly NavigationManager _navigationManager = navigationManager;
 
     public async Task<IEnumerable<string>> GetFilesAsync()
     {
+        if (_httpClient.BaseAddress is null)
+        {
+            _httpClient.BaseAddress = new Uri(_navigationManager.BaseUri);
+        }
+
         return await _httpClient.GetFromJsonAsync<IEnumerable<string>>("api/files")
             ?? Enumerable.Empty<string>();
     }


### PR DESCRIPTION
## Summary
- ensure `HttpClient` has a base address when requesting file list

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6847ff017a648322ba855249d8ac26ab