### PR TITLE
Remove unnecessary framework reference

### DIFF
--- a/BlazorIW/BlazorIW.csproj
+++ b/BlazorIW/BlazorIW.csproj
@@ -12,7 +12,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
## Summary
- remove explicit `Microsoft.AspNetCore.App` FrameworkReference which generated build warnings

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684800530a6c832285405c11b45efe63