### PR TITLE
Show permissions in file list

### DIFF
--- a/BlazorIW.Client/Pages/FileList.razor
+++ b/BlazorIW.Client/Pages/FileList.razor
@@ -6,29 +6,40 @@
 
 <h1>Files under wwwroot</h1>
 
-@if (fileNames == null)
+@if (files == null)
 {
     <p>Loading...</p>
 }
-else if (!fileNames.Any())
+else if (!files.Any())
 {
     <p>No files found.</p>
 }
 else
 {
-    <ul>
-        @foreach (var file in fileNames)
-        {
-            <li>@file</li>
-        }
-    </ul>
+    <table class="table">
+        <thead>
+            <tr>
+                <th>Path</th>
+                <th>Attributes</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach (var file in files)
+            {
+                <tr>
+                    <td>@file.Path</td>
+                    <td>@file.Attributes</td>
+                </tr>
+            }
+        </tbody>
+    </table>
 }
 
 @code {
-    private IEnumerable<string>? fileNames;
+    private IEnumerable<WebRootFileInfo>? files;
 
     protected override async Task OnInitializedAsync()
     {
-        fileNames = await FileService.GetFilesAsync();
+        files = await FileService.GetFilesAsync();
     }
 }

--- a/BlazorIW.Client/Services/FileService.cs
+++ b/BlazorIW.Client/Services/FileService.cs
@@ -3,19 +3,21 @@ using Microsoft.AspNetCore.Components;
 
 namespace BlazorIW.Client.Services;
 
+public record WebRootFileInfo(string Path, string Attributes);
+
 public class FileService(HttpClient httpClient, NavigationManager navigationManager)
 {
     private readonly HttpClient _httpClient = httpClient;
     private readonly NavigationManager _navigationManager = navigationManager;
 
-    public async Task<IEnumerable<string>> GetFilesAsync()
+    public async Task<IEnumerable<WebRootFileInfo>> GetFilesAsync()
     {
         if (_httpClient.BaseAddress is null)
         {
             _httpClient.BaseAddress = new Uri(_navigationManager.BaseUri);
         }
 
-        return await _httpClient.GetFromJsonAsync<IEnumerable<string>>("api/files")
-            ?? Enumerable.Empty<string>();
+        return await _httpClient.GetFromJsonAsync<IEnumerable<WebRootFileInfo>>("api/files")
+            ?? Enumerable.Empty<WebRootFileInfo>();
     }
 }

--- a/BlazorIW.Client/_Imports.razor
+++ b/BlazorIW.Client/_Imports.razor
@@ -8,3 +8,4 @@
 @using Microsoft.AspNetCore.Components.Web.Virtualization
 @using Microsoft.JSInterop
 @using BlazorIW.Client
+@using BlazorIW.Client.Services


### PR DESCRIPTION
## Summary
- add `WebRootFileInfo` model for server and client
- update `WebRootFileService` to return file attributes
- expose `WebRootFileInfo` via FileService and show in UI
- include services namespace in Blazor client imports

## Testing
- `dotnet build BlazorIW.sln -c Release` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848051c27948322bac980999aaadbd0