### PR TITLE
Show permissions and owner in File List

### DIFF
--- a/BlazorIW.Client/Pages/FileList.razor
+++ b/BlazorIW.Client/Pages/FileList.razor
@@ -20,7 +20,8 @@ else
         <thead>
             <tr>
                 <th>Path</th>
-                <th>Attributes</th>
+                <th>Owner</th>
+                <th>Permissions</th>
             </tr>
         </thead>
         <tbody>
@@ -28,7 +29,8 @@ else
             {
                 <tr>
                     <td>@file.Path</td>
-                    <td>@file.Attributes</td>
+                    <td>@file.Owner</td>
+                    <td>@file.Permissions</td>
                 </tr>
             }
         </tbody>

--- a/BlazorIW.Client/Services/FileService.cs
+++ b/BlazorIW.Client/Services/FileService.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.Components;
 
 namespace BlazorIW.Client.Services;
 
-public record WebRootFileInfo(string Path, string Attributes);
+public record WebRootFileInfo(string Path, string Owner, string Permissions);
 
 public class FileService(HttpClient httpClient, NavigationManager navigationManager)
 {


### PR DESCRIPTION
## Summary
- extend WebRootFileInfo with owner and permissions
- compute owner and Unix permissions in WebRootFileService
- display owner and permissions in the File List UI

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684806c08c508322b73df77ac50e52cd