### PR TITLE
Fix LangSwitchButton component namespace reference

### DIFF
--- a/BlazorIW.Client/_Imports.razor
+++ b/BlazorIW.Client/_Imports.razor
@@ -9,3 +9,4 @@
 @using Microsoft.JSInterop
 @using BlazorIW.Client
 @using BlazorIW.Client.Services
+@using BlazorIW.Components.LangSwitcher


### PR DESCRIPTION
## Summary
- include LangSwitchButton namespace in client `_Imports.razor`

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684806df3cdc8322ab95fefa65c59225