### PR TITLE
Update WebRootFileService to use Unix permissions

### DIFF
--- a/BlazorIW/Services/WebRootFileService.cs
+++ b/BlazorIW/Services/WebRootFileService.cs
@@ -1,7 +1,5 @@
 using Microsoft.AspNetCore.Hosting;
 using System.IO;
-using System.Runtime.InteropServices;
-using System.Security.Principal;
 
 namespace BlazorIW.Services;
 
@@ -32,24 +30,11 @@ public class WebRootFileService(IWebHostEnvironment env)
                 {
                     try
                     {
-                        var info = new FileInfo(entry.PhysicalPath);
-                        owner = info.GetAccessControl()
-                            .GetOwner(typeof(NTAccount))
-                            .ToString();
-
-                        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                        {
-                            permissions = info.Attributes.ToString();
-                        }
-                        else
-                        {
-                            var mode = File.GetUnixFileMode(entry.PhysicalPath);
-                            permissions = UnixModeToString(mode);
-                        }
+                        var mode = File.GetUnixFileMode(entry.PhysicalPath);
+                        permissions = UnixModeToString(mode);
                     }
                     catch
                     {
-                        owner = "Unavailable";
                         permissions = "Unavailable";
                     }
                 }


### PR DESCRIPTION
## Summary
- switch `WebRootFileService` to call `File.GetUnixFileMode`
- drop unused using directives

## Testing
- `dotnet test --no-build` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68480867b40c8322ba73847fe910b83c