### PR TITLE
Add file fetch assessment

### DIFF
--- a/BlazorIW.Client/Pages/FileList.razor
+++ b/BlazorIW.Client/Pages/FileList.razor
@@ -3,6 +3,7 @@
 <PageTitle>File List</PageTitle>
 
 @inject BlazorIW.Client.Services.FileService FileService
+@inject HttpClient Http
 
 <h1>Files under wwwroot</h1>
 
@@ -16,11 +17,12 @@ else if (!files.Any())
 }
 else
 {
+    <button class="btn btn-primary mb-2" @onclick="AssessFiles" disabled="@isAssessing">Start Assessment</button>
     <table class="table">
         <thead>
             <tr>
                 <th>Path</th>
-                <th>Attributes</th>
+                <th>Status</th>
             </tr>
         </thead>
         <tbody>
@@ -28,7 +30,7 @@ else
             {
                 <tr>
                     <td>@file.Path</td>
-                    <td>@file.Attributes</td>
+                    <td>@GetStatus(file.Path)</td>
                 </tr>
             }
         </tbody>
@@ -37,9 +39,40 @@ else
 
 @code {
     private IEnumerable<WebRootFileInfo>? files;
+    private readonly Dictionary<string, string> statuses = new();
+    private bool isAssessing;
 
     protected override async Task OnInitializedAsync()
     {
         files = await FileService.GetFilesAsync();
+    }
+
+    private string GetStatus(string path) => statuses.TryGetValue(path, out var s) ? s : string.Empty;
+
+    private async Task AssessFiles()
+    {
+        if (files == null)
+        {
+            return;
+        }
+
+        isAssessing = true;
+        foreach (var file in files)
+        {
+            statuses[file.Path] = "Checking...";
+            StateHasChanged();
+            try
+            {
+                using var request = new HttpRequestMessage(HttpMethod.Head, file.Path);
+                using var response = await Http.SendAsync(request);
+                statuses[file.Path] = response.IsSuccessStatusCode ? "Available" : $"Failed ({(int)response.StatusCode})";
+            }
+            catch
+            {
+                statuses[file.Path] = "Error";
+            }
+            StateHasChanged();
+        }
+        isAssessing = false;
     }
 }


### PR DESCRIPTION
## Summary
- add button to FileList to check each wwwroot file's accessibility
- show per-file status as the check runs

## Testing
- `dotnet build BlazorIW.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68481451ad348322bdc31badaa5c8035