### PR TITLE
Remove unused ProtectedBrowserStorage reference

### DIFF
--- a/BlazorIW.Client/BlazorIW.Client.csproj
+++ b/BlazorIW.Client/BlazorIW.Client.csproj
@@ -12,7 +12,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.CustomElements" Version="9.0.5" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.5" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="9.0.5" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.ProtectedBrowserStorage" Version="9.0.5" />
   </ItemGroup>
 
 </Project>

--- a/BlazorIW.Client/Program.cs
+++ b/BlazorIW.Client/Program.cs
@@ -2,7 +2,6 @@ using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using BlazorIW.Client.Pages;
 using BlazorIW.Client.Services;
-using Microsoft.AspNetCore.Components.WebAssembly.ProtectedBrowserStorage;
 
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);

--- a/BlazorIW.Client/_Imports.razor
+++ b/BlazorIW.Client/_Imports.razor
@@ -7,6 +7,5 @@
 @using static Microsoft.AspNetCore.Components.Web.RenderMode
 @using Microsoft.AspNetCore.Components.Web.Virtualization
 @using Microsoft.JSInterop
-@using Microsoft.AspNetCore.Components.WebAssembly.ProtectedBrowserStorage
 @using BlazorIW.Client
 @using BlazorIW.Client.Services


### PR DESCRIPTION
## Summary
- remove the `Microsoft.AspNetCore.Components.WebAssembly.ProtectedBrowserStorage` package
- drop unused usings referencing ProtectedBrowserStorage

## Testing
- `dotnet test` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848154de7ec8322a261cee6e976ca86