### PR TITLE
Fix ProtectedLocalStorage import

### DIFF
--- a/BlazorIW.Client/Program.cs
+++ b/BlazorIW.Client/Program.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using BlazorIW.Client.Pages;
 using BlazorIW.Client.Services;
+using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage;
 
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);

--- a/BlazorIW.Client/_Imports.razor
+++ b/BlazorIW.Client/_Imports.razor
@@ -9,3 +9,4 @@
 @using Microsoft.JSInterop
 @using BlazorIW.Client
 @using BlazorIW.Client.Services
+@using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage

--- a/BlazorIW/Components/_Imports.razor
+++ b/BlazorIW/Components/_Imports.razor
@@ -10,3 +10,4 @@
 @using BlazorIW
 @using BlazorIW.Client
 @using BlazorIW.Components
+@using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage


### PR DESCRIPTION
## Summary
- add missing using for `ProtectedLocalStorage` in Blazor Client project and component imports

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848165c5fc0832299077e8230358880