### PR TITLE
Implement file accessibility assessment

### DIFF
--- a/BlazorIW.Client/Pages/FileList.razor
+++ b/BlazorIW.Client/Pages/FileList.razor
@@ -16,11 +16,12 @@ else if (!files.Any())
 }
 else
 {
+    <button class="btn btn-primary mb-3" @onclick="StartAssessment" disabled="@isAssessing">Start Assessment</button>
     <table class="table">
         <thead>
             <tr>
                 <th>Path</th>
-                <th>Attributes</th>
+                <th>Status</th>
             </tr>
         </thead>
         <tbody>
@@ -28,7 +29,7 @@ else
             {
                 <tr>
                     <td>@file.Path</td>
-                    <td>@file.Attributes</td>
+                    <td>@file.Status</td>
                 </tr>
             }
         </tbody>
@@ -36,10 +37,37 @@ else
 }
 
 @code {
-    private IEnumerable<WebRootFileInfo>? files;
+    private List<FileStatusInfo>? files;
+    private bool isAssessing;
 
     protected override async Task OnInitializedAsync()
     {
-        files = await FileService.GetFilesAsync();
+        var fileData = await FileService.GetFilesAsync();
+        files = fileData
+            .Select(f => new FileStatusInfo(f.Path, "Not checked"))
+            .ToList();
     }
+
+    private async Task StartAssessment()
+    {
+        if (files is null)
+        {
+            return;
+        }
+
+        isAssessing = true;
+
+        foreach (var file in files)
+        {
+            file.Status = "Checking...";
+            StateHasChanged();
+            var ok = await FileService.IsFileAccessibleAsync(file.Path);
+            file.Status = ok ? "Accessible" : "Unavailable";
+            StateHasChanged();
+        }
+
+        isAssessing = false;
+    }
+
+    private record FileStatusInfo(string Path, string Status);
 }

--- a/BlazorIW.Client/Services/FileService.cs
+++ b/BlazorIW.Client/Services/FileService.cs
@@ -20,4 +20,23 @@ public class FileService(HttpClient httpClient, NavigationManager navigationMana
         return await _httpClient.GetFromJsonAsync<IEnumerable<WebRootFileInfo>>("api/files")
             ?? Enumerable.Empty<WebRootFileInfo>();
     }
+
+    public async Task<bool> IsFileAccessibleAsync(string path)
+    {
+        if (_httpClient.BaseAddress is null)
+        {
+            _httpClient.BaseAddress = new Uri(_navigationManager.BaseUri);
+        }
+
+        try
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Head, path);
+            using var response = await _httpClient.SendAsync(request);
+            return response.IsSuccessStatusCode;
+        }
+        catch
+        {
+            return false;
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- add a helper in `FileService` to check whether a file can be fetched via an HTTP HEAD request
- update the File List page with a "Start Assessment" button and display status for each file during checks

## Testing
- `dotnet test --no-build` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684818c047a883229e1d0295854517cd