### PR TITLE
Add browser storage demo page

### DIFF
--- a/BlazorIW.Client/Layout/NavMenu.razor
+++ b/BlazorIW.Client/Layout/NavMenu.razor
@@ -37,6 +37,12 @@
         </div>
 
         <div class="nav-item px-3">
+            <NavLink class="nav-link" href="storage">
+                <span class="bi bi-hdd-nav-menu" aria-hidden="true"></span> Storage
+            </NavLink>
+        </div>
+
+        <div class="nav-item px-3">
             <NavLink class="nav-link" href="auth">
                 <span class="bi bi-lock-nav-menu" aria-hidden="true"></span> Auth Required
             </NavLink>

--- a/BlazorIW.Client/Pages/Storage.razor
+++ b/BlazorIW.Client/Pages/Storage.razor
@@ -1,0 +1,48 @@
+@page "/storage"
+
+<PageTitle>Storage Demo</PageTitle>
+
+<h1>Browser Storage</h1>
+
+<ul>
+    <li>Capacity: ~5&nbsp;MB (per origin)</li>
+    <li>Security: &gt; unencrypted</li>
+    <li>Lifetime:
+        <code>sessionStorage</code> dies when the tab/window closes,
+        <code>localStorage</code> survives across browser restarts
+    </li>
+</ul>
+
+<h2>Using Blazored.LocalStorage</h2>
+
+<p>Install</p>
+<pre><code>dotnet add package Blazored.LocalStorage</code></pre>
+
+<p>Register in <code>Program.cs</code></p>
+<pre>@registrationSnippet</pre>
+
+<p>Inject &amp; use in a component</p>
+<pre>@usageSnippet</pre>
+
+<p>When to use: small, non-sensitive settings or caches where encryption isn&rsquo;t critical.</p>
+
+@code {
+    private readonly MarkupString registrationSnippet =
+        (MarkupString)"builder.Services.AddBlazoredLocalStorage();";
+
+    private readonly MarkupString usageSnippet = (MarkupString)@"@inject Blazored.LocalStorage.ILocalStorageService localStorage
+
+@code {
+  protected override async Task OnInitializedAsync()
+  {
+    // Save
+    await localStorage.SetItemAsync(""userPrefs"", new UserPreferences { Theme = ""dark"" });
+
+    // Retrieve
+    var prefs = await localStorage.GetItemAsync<UserPreferences>(""userPrefs"");
+
+    // Remove
+    await localStorage.RemoveItemAsync(""userPrefs"");
+  }
+}";
+}


### PR DESCRIPTION
## Summary
- add storage demo page explaining usage of `Blazored.LocalStorage`
- link the new page from the navigation menu

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68481e00058c8322b6270b140a3172a9