### PR TITLE
Add browser storage demo page

### DIFF
--- a/BlazorIW.Client/Layout/NavMenu.razor
+++ b/BlazorIW.Client/Layout/NavMenu.razor
@@ -37,6 +37,12 @@
         </div>
 
         <div class="nav-item px-3">
+            <NavLink class="nav-link" href="storage">
+                <span class="bi bi-plus-square-fill-nav-menu" aria-hidden="true"></span> Storage Demo
+            </NavLink>
+        </div>
+
+        <div class="nav-item px-3">
             <NavLink class="nav-link" href="auth">
                 <span class="bi bi-lock-nav-menu" aria-hidden="true"></span> Auth Required
             </NavLink>

--- a/BlazorIW.Client/Pages/StorageDemo.razor
+++ b/BlazorIW.Client/Pages/StorageDemo.razor
@@ -1,0 +1,68 @@
+@page "/storage"
+
+<PageTitle>Storage Demo</PageTitle>
+
+@inject BrowserStorageService Storage
+
+<h1>Browser Storage Demo</h1>
+
+<div class="mb-3">
+    <input class="form-control" placeholder="Enter value" @bind="inputValue" />
+</div>
+
+<div class="mb-3">
+    <button class="btn btn-primary me-1" @onclick="SaveLocalAsync">Save Local</button>
+    <button class="btn btn-secondary me-1" @onclick="LoadLocalAsync">Load Local</button>
+    <button class="btn btn-outline-danger me-1" @onclick="ClearLocalAsync">Clear Local</button>
+</div>
+
+<div class="mb-3">
+    <button class="btn btn-primary me-1" @onclick="SaveSessionAsync">Save Session</button>
+    <button class="btn btn-secondary me-1" @onclick="LoadSessionAsync">Load Session</button>
+    <button class="btn btn-outline-danger me-1" @onclick="ClearSessionAsync">Clear Session</button>
+</div>
+
+<p>Stored value: @storedValue</p>
+
+@code {
+    private string? inputValue;
+    private string? storedValue;
+    private const string StorageKey = "storage-demo-value";
+
+    protected override async Task OnInitializedAsync()
+    {
+        storedValue = await Storage.GetLocalStorageAsync(StorageKey);
+    }
+
+    private async Task SaveLocalAsync()
+    {
+        await Storage.SetLocalStorageAsync(StorageKey, inputValue ?? string.Empty);
+    }
+
+    private async Task LoadLocalAsync()
+    {
+        storedValue = await Storage.GetLocalStorageAsync(StorageKey);
+    }
+
+    private async Task ClearLocalAsync()
+    {
+        await Storage.RemoveLocalStorageAsync(StorageKey);
+        storedValue = null;
+    }
+
+    private async Task SaveSessionAsync()
+    {
+        await Storage.SetSessionStorageAsync(StorageKey, inputValue ?? string.Empty);
+    }
+
+    private async Task LoadSessionAsync()
+    {
+        storedValue = await Storage.GetSessionStorageAsync(StorageKey);
+    }
+
+    private async Task ClearSessionAsync()
+    {
+        await Storage.RemoveSessionStorageAsync(StorageKey);
+        storedValue = null;
+    }
+}

--- a/BlazorIW.Client/Program.cs
+++ b/BlazorIW.Client/Program.cs
@@ -11,6 +11,7 @@ builder.Services.AddCascadingAuthenticationState();
 builder.Services.AddAuthenticationStateDeserialization();
 builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
 builder.Services.AddScoped<FileService>();
+builder.Services.AddScoped<BrowserStorageService>();
 
 // Register Counter component as custom element <my-counter>
 builder.RootComponents.RegisterCustomElement<Counter>("my-counter");

--- a/BlazorIW.Client/Services/BrowserStorageService.cs
+++ b/BlazorIW.Client/Services/BrowserStorageService.cs
@@ -1,0 +1,31 @@
+using Microsoft.JSInterop;
+
+namespace BlazorIW.Client.Services;
+
+public class BrowserStorageService
+{
+    private readonly IJSRuntime _js;
+
+    public BrowserStorageService(IJSRuntime js)
+    {
+        _js = js;
+    }
+
+    public ValueTask SetLocalStorageAsync(string key, string value) =>
+        _js.InvokeVoidAsync("localStorage.setItem", key, value);
+
+    public ValueTask<string?> GetLocalStorageAsync(string key) =>
+        _js.InvokeAsync<string?>("localStorage.getItem", key);
+
+    public ValueTask RemoveLocalStorageAsync(string key) =>
+        _js.InvokeVoidAsync("localStorage.removeItem", key);
+
+    public ValueTask SetSessionStorageAsync(string key, string value) =>
+        _js.InvokeVoidAsync("sessionStorage.setItem", key, value);
+
+    public ValueTask<string?> GetSessionStorageAsync(string key) =>
+        _js.InvokeAsync<string?>("sessionStorage.getItem", key);
+
+    public ValueTask RemoveSessionStorageAsync(string key) =>
+        _js.InvokeVoidAsync("sessionStorage.removeItem", key);
+}


### PR DESCRIPTION
## Summary
- implement `BrowserStorageService` for local and session storage
- register the service for DI and expose `/storage` demo page
- add navigation link to the new demo

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684821a9da488322ba1c6670d5f3a8c1