### PR TITLE
Fix BrowserStorageService DI and prerender

### DIFF
--- a/BlazorIW.Client/Pages/StorageDemo.razor
+++ b/BlazorIW.Client/Pages/StorageDemo.razor
@@ -1,4 +1,5 @@
 @page "/storage"
+@rendermode InteractiveWebAssembly
 
 <PageTitle>Storage Demo</PageTitle>
 
@@ -29,9 +30,13 @@
     private string? storedValue;
     private const string StorageKey = "storage-demo-value";
 
-    protected override async Task OnInitializedAsync()
+    protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        storedValue = await Storage.GetLocalStorageAsync(StorageKey);
+        if (firstRender)
+        {
+            storedValue = await Storage.GetLocalStorageAsync(StorageKey);
+            StateHasChanged();
+        }
     }
 
     private async Task SaveLocalAsync()

--- a/BlazorIW/Program.cs
+++ b/BlazorIW/Program.cs
@@ -49,6 +49,7 @@ builder.Services.AddHttpClient();
 builder.Services.AddScoped<ProtectedLocalStorage>();
 builder.Services.AddScoped<WebRootFileService>();
 builder.Services.AddScoped<FileService>();
+builder.Services.AddScoped<BrowserStorageService>();
 
 var app = builder.Build();
 


### PR DESCRIPTION
## Summary
- add BrowserStorageService to server DI container
- make `StorageDemo` interactive and load storage after first render

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68482387868883229287a8dd402d94c1