### PR TITLE
Add language preference toggle

### DIFF
--- a/BlazorIW.Client/Layout/MainLayout.razor
+++ b/BlazorIW.Client/Layout/MainLayout.razor
@@ -7,7 +7,7 @@
 
     <main>
         <div class="top-row px-4">
-            LangSwitchButton should be here
+            <LangSwitchButton />
         </div>
 
         <article class="content px-4">

--- a/BlazorIW.Client/Program.cs
+++ b/BlazorIW.Client/Program.cs
@@ -12,6 +12,7 @@ builder.Services.AddAuthenticationStateDeserialization();
 builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
 builder.Services.AddScoped<FileService>();
 builder.Services.AddScoped<BrowserStorageService>();
+builder.Services.AddScoped<LocalizationService>();
 
 // Register Counter component as custom element <my-counter>
 builder.RootComponents.RegisterCustomElement<Counter>("my-counter");

--- a/BlazorIW.Client/Services/LocalizationService.cs
+++ b/BlazorIW.Client/Services/LocalizationService.cs
@@ -1,0 +1,69 @@
+using System.Globalization;
+using Microsoft.JSInterop;
+
+namespace BlazorIW.Client.Services;
+
+public class LocalizationService
+{
+    private readonly IJSRuntime _js;
+    private readonly BrowserStorageService _storage;
+    private bool _loaded;
+    public event Action? OnChange;
+
+    public LocalizationService(IJSRuntime js, BrowserStorageService storage)
+    {
+        _js = js;
+        _storage = storage;
+        CurrentCulture = CultureInfo.CurrentCulture;
+    }
+
+    public CultureInfo CurrentCulture { get; private set; }
+
+    public async Task LoadCultureAsync()
+    {
+        if (_loaded)
+        {
+            return;
+        }
+
+        var culture = await _storage.GetLocalStorageAsync("blazorCulture");
+        if (string.IsNullOrEmpty(culture))
+        {
+            try
+            {
+                var langs = await _js.InvokeAsync<string[]>("localization.getBrowserLanguages");
+                if (langs != null && langs.Any(l => l.StartsWith("ja", StringComparison.OrdinalIgnoreCase)))
+                {
+                    culture = "ja";
+                }
+                else
+                {
+                    culture = "en";
+                }
+            }
+            catch
+            {
+                culture = "en";
+            }
+        }
+
+        SetThreadCulture(culture);
+        _loaded = true;
+        OnChange?.Invoke();
+    }
+
+    public async Task SetCultureAsync(string culture)
+    {
+        await _storage.SetLocalStorageAsync("blazorCulture", culture);
+        SetThreadCulture(culture);
+        OnChange?.Invoke();
+    }
+
+    private void SetThreadCulture(string culture)
+    {
+        var cultureInfo = new CultureInfo(culture);
+        CultureInfo.DefaultThreadCurrentCulture = cultureInfo;
+        CultureInfo.DefaultThreadCurrentUICulture = cultureInfo;
+        CurrentCulture = cultureInfo;
+    }
+}

--- a/BlazorIW.Client/_Imports.razor
+++ b/BlazorIW.Client/_Imports.razor
@@ -9,3 +9,4 @@
 @using Microsoft.JSInterop
 @using BlazorIW.Client
 @using BlazorIW.Client.Services
+@using BlazorIW.Components.LangSwitcher

--- a/BlazorIW/Components/App.razor
+++ b/BlazorIW/Components/App.razor
@@ -20,6 +20,7 @@
     <script src="@Assets["libman/d3-hexbin.min.js"]"></script>
     <script src="@Assets["js/d3demo.js"]"></script>
     <script src="@Assets["js/efinspection.js"]"></script>
+    <script src="@Assets["js/localization.js"]"></script>
 
     <!-- 1) Blazor Custom Elements runtime -->
     <script type="module"

--- a/BlazorIW/Components/LangSwitcher/LangSwitchButton.razor
+++ b/BlazorIW/Components/LangSwitcher/LangSwitchButton.razor
@@ -1,0 +1,76 @@
+@using BlazorIW.Client.Services
+@implements IDisposable
+@inject LocalizationService Localization
+@inject NavigationManager NavigationManager
+@rendermode InteractiveWebAssembly
+
+<div class="dropdown lang-switch">
+    <button class="btn btn-secondary dropdown-toggle" @onclick="ToggleDropdown">
+        🌐 @GetCurrentCultureLabel()
+    </button>
+    <ul class="dropdown-menu @(GetDropdownMenuClass())">
+        <li>
+            <button class="dropdown-item @(GetActiveClass("en"))" @onclick="@(() => SetLanguage("en"))">
+                English @GetCheckmark("en")
+            </button>
+        </li>
+        <li>
+            <button class="dropdown-item @(GetActiveClass("ja"))" @onclick="@(() => SetLanguage("ja"))">
+                日本語 @GetCheckmark("ja")
+            </button>
+        </li>
+    </ul>
+</div>
+
+@code {
+    private bool isDropdownOpen;
+    private bool initialized = false;
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender && !initialized)
+        {
+            await Localization.LoadCultureAsync();
+            Localization.OnChange += StateHasChanged;
+            initialized = true;
+            StateHasChanged();
+        }
+    }
+
+    private void ToggleDropdown()
+    {
+        isDropdownOpen = !isDropdownOpen;
+    }
+
+    private async Task SetLanguage(string culture)
+    {
+        isDropdownOpen = false;
+        await Localization.SetCultureAsync(culture);
+        NavigationManager.NavigateTo(NavigationManager.Uri, forceLoad: true);
+    }
+
+    private string GetCurrentCultureLabel()
+    {
+        return Localization.CurrentCulture.Name.StartsWith("ja") ? "JA" : "EN";
+    }
+
+    private string GetDropdownMenuClass()
+    {
+        return isDropdownOpen ? "show" : string.Empty;
+    }
+
+    private string GetActiveClass(string culture)
+    {
+        return Localization.CurrentCulture.Name.StartsWith(culture) ? "active" : string.Empty;
+    }
+
+    private string GetCheckmark(string culture)
+    {
+        return Localization.CurrentCulture.Name.StartsWith(culture) ? "✔️" : string.Empty;
+    }
+
+    public void Dispose()
+    {
+        Localization.OnChange -= StateHasChanged;
+    }
+}

--- a/BlazorIW/Components/LangSwitcher/LangSwitchButton.razor.css
+++ b/BlazorIW/Components/LangSwitcher/LangSwitchButton.razor.css
@@ -1,0 +1,10 @@
+@media (min-width: 641px) {
+    .lang-switch {
+        position: relative;
+    }
+
+    .lang-switch .dropdown-menu {
+        right: 0;
+        left: auto;
+    }
+}

--- a/BlazorIW/Program.cs
+++ b/BlazorIW/Program.cs
@@ -50,6 +50,7 @@ builder.Services.AddScoped<ProtectedLocalStorage>();
 builder.Services.AddScoped<WebRootFileService>();
 builder.Services.AddScoped<FileService>();
 builder.Services.AddScoped<BrowserStorageService>();
+builder.Services.AddScoped<LocalizationService>();
 
 var app = builder.Build();
 

--- a/BlazorIW/wwwroot/js/localization.js
+++ b/BlazorIW/wwwroot/js/localization.js
@@ -1,0 +1,17 @@
+window.localization = {
+  getBrowserLanguages: function () {
+    if (navigator.languages && navigator.languages.length) {
+      return navigator.languages;
+    }
+    if (navigator.language) {
+      return [navigator.language];
+    }
+    return [];
+  },
+  getPreferredLanguage: function () {
+    return localStorage.getItem('blazorCulture');
+  },
+  setPreferredLanguage: function (culture) {
+    localStorage.setItem('blazorCulture', culture);
+  }
+};


### PR DESCRIPTION
## Summary
- implement `LocalizationService` using `BrowserStorageService`
- add `LangSwitchButton` component and CSS
- wire up language switcher in layout and host page
- register service in client and server programs
- include localization JS helpers

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684824ffceac83229e517fce0475d4ff