### PR TITLE
Add folder demo nav item with opacity toggle

### DIFF
--- a/BlazorIW.Client/Layout/NavMenu.razor
+++ b/BlazorIW.Client/Layout/NavMenu.razor
@@ -2,16 +2,17 @@
 
 @inject NavigationManager NavigationManager
 
-<div class="top-row ps-3 navbar navbar-dark">
-    <div class="container-fluid">
-        <a class="navbar-brand" href="">BlazorIW</a>
+<div class="menu-bar @(menuOpaque ? "menu-bar-opaque" : string.Empty)" @onclick="ToggleMenuOpacity">
+    <div class="top-row ps-3 navbar navbar-dark">
+        <div class="container-fluid">
+            <a class="navbar-brand" href="">BlazorIW</a>
+        </div>
     </div>
-</div>
 
-<input type="checkbox" title="Navigation menu" class="navbar-toggler" />
+    <input type="checkbox" title="Navigation menu" class="navbar-toggler" />
 
-<div class="nav-scrollable" onclick="document.querySelector('.navbar-toggler').click()">
-    <nav class="nav flex-column">
+    <div class="nav-scrollable" onclick="document.querySelector('.navbar-toggler').click()">
+        <nav class="nav flex-column">
         <div class="nav-item px-3">
             <NavLink class="nav-link" href="" Match="NavLinkMatch.All">
                 <span class="bi bi-house-door-fill-nav-menu" aria-hidden="true"></span> Home
@@ -33,6 +34,12 @@
         <div class="nav-item px-3">
             <NavLink class="nav-link" href="files">
                 <span class="bi bi-folder-nav-menu" aria-hidden="true"></span> File List
+            </NavLink>
+        </div>
+
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="folder-demo">
+                <span class="bi bi-folder-nav-menu" aria-hidden="true"></span> Folder Demo
             </NavLink>
         </div>
 
@@ -80,10 +87,13 @@
                 </NotAuthorized>
             </AuthorizeView>
         }
-    </nav>
+
+        </nav>
+    </div>
 </div>
 
 @code {
+    private bool menuOpaque;
     private string? currentUrl;
 
     protected override void OnInitialized()
@@ -96,6 +106,11 @@
     {
         currentUrl = NavigationManager.ToBaseRelativePath(e.Location);
         StateHasChanged();
+    }
+
+    private void ToggleMenuOpacity()
+    {
+        menuOpaque = !menuOpaque;
     }
 
     public void Dispose()

--- a/BlazorIW.Client/Layout/NavMenu.razor.css
+++ b/BlazorIW.Client/Layout/NavMenu.razor.css
@@ -11,6 +11,14 @@
     background: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'%3e%3cpath stroke='rgba%28255, 255, 255, 0.55%29' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e") no-repeat center/1.75rem rgba(255, 255, 255, 0.1);
 }
 
+.menu-bar {
+    background-color: transparent;
+}
+
+.menu-bar-opaque {
+    background-color: rgba(0, 0, 0, 0.3);
+}
+
 .navbar-toggler:checked {
     background-color: rgba(255, 255, 255, 0.5);
 }

--- a/BlazorIW.Client/Pages/FolderDemo.razor
+++ b/BlazorIW.Client/Pages/FolderDemo.razor
@@ -1,0 +1,7 @@
+@page "/folder-demo"
+
+<PageTitle>Folder Demo</PageTitle>
+
+<h1>Folder Demo</h1>
+
+<p>More features coming soon.</p>


### PR DESCRIPTION
## Summary
- add `FolderDemo` page
- enable toggling the menu bar opacity on click
- add a "Folder Demo" item to the navigation menu

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684832b82e9483229f9d09ed1800d109