### PR TITLE
Add WordPress posts page

### DIFF
--- a/BlazorIW.Client/Layout/NavMenu.razor
+++ b/BlazorIW.Client/Layout/NavMenu.razor
@@ -41,6 +41,11 @@
                 <span class="bi bi-plus-square-fill-nav-menu" aria-hidden="true"></span> Storage Demo
             </NavLink>
         </div>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="wordpress">
+                <span class="bi bi-journal-text-nav-menu" aria-hidden="true"></span> WordPress
+            </NavLink>
+        </div>
 
         <div class="nav-item px-3">
             <NavLink class="nav-link" href="auth">

--- a/BlazorIW.Client/Pages/WordPress.razor
+++ b/BlazorIW.Client/Pages/WordPress.razor
@@ -1,0 +1,66 @@
+@page "/wordpress"
+@rendermode InteractiveWebAssembly
+@using System.Text.Json
+
+<PageTitle>WordPress Posts</PageTitle>
+
+@inject WordPressService WordPress
+
+<h1>WordPress Posts</h1>
+
+<div class="mb-3">
+    <input class="form-control" placeholder="Enter base API URL" @bind="baseUrl" />
+</div>
+<button class="btn btn-primary mb-3" @onclick="LoadPosts">Fetch Posts</button>
+
+@if (isLoading)
+{
+    <p><em>Loading...</em></p>
+}
+else if (!string.IsNullOrEmpty(errorMessage))
+{
+    <p class="text-danger">@errorMessage</p>
+}
+else if (postsJson != null)
+{
+    <pre>@postsJson</pre>
+}
+
+@code {
+    private string? baseUrl;
+    private List<JsonElement>? posts;
+    private bool isLoading;
+    private string? errorMessage;
+
+    private string? postsJson => posts is null ? null : JsonSerializer.Serialize(posts, new JsonSerializerOptions { WriteIndented = true });
+
+    private async Task LoadPosts()
+    {
+        if (string.IsNullOrWhiteSpace(baseUrl))
+        {
+            errorMessage = "Please enter a URL.";
+            posts = null;
+            return;
+        }
+
+        isLoading = true;
+        errorMessage = null;
+        posts = null;
+        try
+        {
+            posts = await WordPress.FetchPostsAsync(baseUrl);
+            if (posts.Count == 0)
+            {
+                errorMessage = "No posts found.";
+            }
+        }
+        catch (Exception ex)
+        {
+            errorMessage = ex.Message;
+        }
+        finally
+        {
+            isLoading = false;
+        }
+    }
+}

--- a/BlazorIW.Client/Program.cs
+++ b/BlazorIW.Client/Program.cs
@@ -12,6 +12,7 @@ builder.Services.AddAuthenticationStateDeserialization();
 builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
 builder.Services.AddScoped<FileService>();
 builder.Services.AddScoped<BrowserStorageService>();
+builder.Services.AddScoped<WordPressService>();
 builder.Services.AddScoped<LocalizationService>();
 
 // Register Counter component as custom element <my-counter>

--- a/BlazorIW.Client/Services/WordPressService.cs
+++ b/BlazorIW.Client/Services/WordPressService.cs
@@ -1,0 +1,39 @@
+using System.Text.Json;
+
+namespace BlazorIW.Client.Services;
+
+public class WordPressService(HttpClient httpClient)
+{
+    private readonly HttpClient _httpClient = httpClient;
+
+    public async Task<List<JsonElement>> FetchPostsAsync(string baseUrl)
+    {
+        var posts = new List<JsonElement>();
+        int page = 1;
+        while (true)
+        {
+            var url = $"{baseUrl.TrimEnd('/')}/posts?per_page=100&page={page}";
+            try
+            {
+                var response = await _httpClient.GetAsync(url);
+                response.EnsureSuccessStatusCode();
+                var json = await response.Content.ReadAsStringAsync();
+                using var doc = JsonDocument.Parse(json);
+                if (doc.RootElement.ValueKind != JsonValueKind.Array || doc.RootElement.GetArrayLength() == 0)
+                {
+                    break;
+                }
+                foreach (var item in doc.RootElement.EnumerateArray())
+                {
+                    posts.Add(item.Clone());
+                }
+            }
+            catch
+            {
+                break;
+            }
+            page++;
+        }
+        return posts;
+    }
+}


### PR DESCRIPTION
## Summary
- implement `WordPressService` for loading paginated posts from a WordPress API
- add `/wordpress` page to input a base API URL and show downloaded posts
- register the service and link the page in the navigation menu

## Testing
- `dotnet test --no-build` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684850e733448322b548a39d56fae210