### PR TITLE
Add nav links for D3 Demo and Inspector

### DIFF
--- a/BlazorIW.Client/Layout/NavMenu.razor
+++ b/BlazorIW.Client/Layout/NavMenu.razor
@@ -48,6 +48,18 @@
         </div>
 
         <div class="nav-item px-3">
+            <NavLink class="nav-link" href="d3">
+                <span class="bi bi-diagram-3-nav-menu" aria-hidden="true"></span> D3 Demo
+            </NavLink>
+        </div>
+
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="inspect">
+                <span class="bi bi-search-nav-menu" aria-hidden="true"></span> Inspector
+            </NavLink>
+        </div>
+
+        <div class="nav-item px-3">
             <NavLink class="nav-link" href="auth">
                 <span class="bi bi-lock-nav-menu" aria-hidden="true"></span> Auth Required
             </NavLink>


### PR DESCRIPTION
## Summary
- extend sidebar navigation with D3 Demo and Inspector links

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684853f2f57c83228c72d7329f807622