### PR TITLE
Add summary toggle for WordPress posts

### DIFF
--- a/BlazorIW.Client/Pages/WordPress.razor
+++ b/BlazorIW.Client/Pages/WordPress.razor
@@ -1,6 +1,7 @@
 @page "/wordpress"
 @rendermode InteractiveWebAssembly
 @using System.Text.Json
+@using Microsoft.AspNetCore.Components
 
 <PageTitle>WordPress Posts</PageTitle>
 
@@ -13,6 +14,9 @@
     <input class="form-control" placeholder="Enter base API URL" @bind="baseUrl" />
 </div>
 <button class="btn btn-primary mb-3" @onclick="LoadPosts">Fetch Posts</button>
+<button class="btn btn-secondary mb-3 ms-2" @onclick="ToggleSummary" disabled="@(posts is null)">
+    @(showSummary ? "Show JSON" : "Show Summary")
+</button>
 
 @if (isLoading)
 {
@@ -22,9 +26,36 @@ else if (!string.IsNullOrEmpty(errorMessage))
 {
     <p class="text-danger">@errorMessage</p>
 }
-else if (postsJson != null)
+else if (posts != null)
 {
-    <pre>@postsJson</pre>
+    if (showSummary)
+    {
+        <table class="table">
+            <thead>
+                <tr>
+                    <th>Date</th>
+                    <th>Title</th>
+                    <th>Excerpt</th>
+                    <th>Content</th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach (var p in Summaries ?? Enumerable.Empty<PostSummary>())
+                {
+                    <tr>
+                        <td>@p.Date</td>
+                        <td>@((MarkupString)p.Title)</td>
+                        <td>@((MarkupString)p.Excerpt)</td>
+                        <td>@((MarkupString)p.Content)</td>
+                    </tr>
+                }
+            </tbody>
+        </table>
+    }
+    else if (postsJson != null)
+    {
+        <pre>@postsJson</pre>
+    }
 }
 
 @code {
@@ -35,6 +66,16 @@ else if (postsJson != null)
     private List<JsonElement>? posts;
     private bool isLoading;
     private string? errorMessage;
+    private bool showSummary;
+
+    private IEnumerable<PostSummary>? Summaries => posts?.Select(p => new PostSummary(
+        p.GetProperty("date").GetString() ?? string.Empty,
+        p.GetProperty("title").GetProperty("rendered").GetString() ?? string.Empty,
+        p.GetProperty("excerpt").GetProperty("rendered").GetString() ?? string.Empty,
+        p.GetProperty("content").GetProperty("rendered").GetString() ?? string.Empty
+    ));
+
+    private record PostSummary(string Date, string Title, string Excerpt, string Content);
 
     private string? postsJson => posts is null ? null : JsonSerializer.Serialize(posts, new JsonSerializerOptions { WriteIndented = true });
 
@@ -89,5 +130,10 @@ else if (postsJson != null)
         {
             isLoading = false;
         }
+    }
+
+    private void ToggleSummary()
+    {
+        showSummary = !showSummary;
     }
 }


### PR DESCRIPTION
## Summary
- add 'Show Summary' button on the WordPress page
- display posts in a table with date, title, excerpt and content when enabled

## Testing
- `dotnet test --no-build` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_68485dc8665c83228288570fc064dce3