### PR TITLE
Fix WordPress page injection name

### DIFF
--- a/BlazorIW.Client/Pages/WordPress.razor
+++ b/BlazorIW.Client/Pages/WordPress.razor
@@ -5,7 +5,7 @@
 
 <PageTitle>WordPress Posts</PageTitle>
 
-@inject WordPressService WordPress
+@inject WordPressService WordPressSvc
 @inject BrowserStorageService Storage
 
 <h1>WordPress Posts</h1>
@@ -114,7 +114,7 @@ else if (posts != null)
         posts = null;
         try
         {
-            posts = await WordPress.FetchPostsAsync(baseUrl);
+            posts = await WordPressSvc.FetchPostsAsync(baseUrl);
             if (posts.Count == 0)
             {
                 errorMessage = "No posts found.";


### PR DESCRIPTION
## Summary
- rename WordPress page injection field to avoid conflict with class name

## Testing
- `scripts/test.sh` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_68485ef336788322842b0feab24b9b44