### PR TITLE
Rename WordPress page link

### DIFF
--- a/BlazorIW.Client/Layout/NavMenu.razor
+++ b/BlazorIW.Client/Layout/NavMenu.razor
@@ -42,8 +42,8 @@
             </NavLink>
         </div>
         <div class="nav-item px-3">
-            <NavLink class="nav-link" href="wordpress">
-                <span class="bi bi-journal-text-nav-menu" aria-hidden="true"></span> WordPress
+            <NavLink class="nav-link" href="wordpress-posts">
+                <span class="bi bi-journal-text-nav-menu" aria-hidden="true"></span> Wordpress Posts
             </NavLink>
         </div>
 

--- a/BlazorIW.Client/Pages/WordPress.razor
+++ b/BlazorIW.Client/Pages/WordPress.razor
@@ -1,4 +1,4 @@
-@page "/wordpress"
+@page "/wordpress-posts"
 @rendermode InteractiveWebAssembly
 @using System.Text.Json
 @using Microsoft.AspNetCore.Components


### PR DESCRIPTION
## Summary
- rename the `wordpress` page route to `/wordpress-posts`
- update the nav menu entry to "Wordpress Posts"

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848921150a083228b92a7385ffbcd27