### PR TITLE
Add HTML content check in WordPress posts

### DIFF
--- a/BlazorIW.Client/Pages/WordPress.razor
+++ b/BlazorIW.Client/Pages/WordPress.razor
@@ -7,6 +7,7 @@
 
 @inject WordPressService WordPressSvc
 @inject BrowserStorageService Storage
+@inject HtmlContentService HtmlSvc
 
 <h1>WordPress Posts</h1>
 
@@ -52,9 +53,27 @@ else if (posts != null)
             </tbody>
         </table>
     }
-    else if (postsJson != null)
+    else if (posts != null)
     {
-        <pre>@postsJson</pre>
+        <table class="table">
+            <thead>
+                <tr>
+                    <th>Exists</th>
+                    <th>Json</th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach (var p in posts)
+                {
+                    var title = p.GetProperty("title").GetProperty("rendered").GetString() ?? string.Empty;
+                    var json = JsonSerializer.Serialize(p, new JsonSerializerOptions { WriteIndented = true });
+                    <tr>
+                        <td>@(existingTitles.Contains(title) ? "✔" : string.Empty)</td>
+                        <td><pre>@json</pre></td>
+                    </tr>
+                }
+            </tbody>
+        </table>
     }
 }
 
@@ -67,6 +86,7 @@ else if (posts != null)
     private bool isLoading;
     private string? errorMessage;
     private bool showSummary;
+    private HashSet<string> existingTitles = new();
 
     private IEnumerable<PostSummary>? Summaries => posts?.Select(p => new PostSummary(
         p.GetProperty("date").GetString() ?? string.Empty,
@@ -83,6 +103,7 @@ else if (posts != null)
     {
         if (firstRender)
         {
+            existingTitles = await HtmlSvc.GetTitlesAsync();
             baseUrl = await Storage.GetLocalStorageAsync(UrlKey);
             var json = await Storage.GetLocalStorageAsync(PostsKey);
             if (!string.IsNullOrEmpty(json))
@@ -114,6 +135,7 @@ else if (posts != null)
         posts = null;
         try
         {
+            existingTitles = await HtmlSvc.GetTitlesAsync();
             posts = await WordPressSvc.FetchPostsAsync(baseUrl);
             if (posts.Count == 0)
             {

--- a/BlazorIW.Client/Program.cs
+++ b/BlazorIW.Client/Program.cs
@@ -13,6 +13,7 @@ builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.
 builder.Services.AddScoped<FileService>();
 builder.Services.AddScoped<BrowserStorageService>();
 builder.Services.AddScoped<WordPressService>();
+builder.Services.AddScoped<HtmlContentService>();
 builder.Services.AddScoped<LocalizationService>();
 
 // Register Counter component as custom element <my-counter>

--- a/BlazorIW.Client/Services/HtmlContentService.cs
+++ b/BlazorIW.Client/Services/HtmlContentService.cs
@@ -1,0 +1,28 @@
+using System.Net.Http.Json;
+using Microsoft.AspNetCore.Components;
+
+namespace BlazorIW.Client.Services;
+
+public class HtmlContentService(HttpClient httpClient, NavigationManager navigationManager)
+{
+    private readonly HttpClient _httpClient = httpClient;
+    private readonly NavigationManager _navigationManager = navigationManager;
+
+    public async Task<HashSet<string>> GetTitlesAsync()
+    {
+        if (_httpClient.BaseAddress is null)
+        {
+            _httpClient.BaseAddress = new Uri(_navigationManager.BaseUri);
+        }
+
+        try
+        {
+            var titles = await _httpClient.GetFromJsonAsync<List<string>>("api/html-content-titles");
+            return titles is null ? new HashSet<string>() : new HashSet<string>(titles);
+        }
+        catch
+        {
+            return new HashSet<string>();
+        }
+    }
+}

--- a/BlazorIW/Program.cs
+++ b/BlazorIW/Program.cs
@@ -232,6 +232,15 @@ app.MapRazorComponents<App>()
 // Add additional endpoints required by the Identity /Account Razor components.
 app.MapAdditionalIdentityEndpoints();
 
+app.MapGet("/api/html-content-titles", async (ApplicationDbContext db, CancellationToken ct) =>
+{
+    var titles = await db.HtmlContents
+        .Select(h => h.Title)
+        .Distinct()
+        .ToListAsync(ct);
+    return Results.Json(titles);
+});
+
 app.MapGet("/api/files", (WebRootFileService service) => Results.Json(service.GetFiles().ToList()));
 
 app.Run();


### PR DESCRIPTION
## Summary
- introduce endpoint `/api/html-content-titles` to query titles of HTML contents
- add `HtmlContentService` on the client to retrieve available titles
- augment WordPress posts page to show JSON table with a column indicating if a matching HTML content title exists

## Testing
- `scripts/test.sh` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684894782da08322a1783dff3061b4f5