### PR TITLE
Register HtmlContentService on server

### DIFF
--- a/BlazorIW/Program.cs
+++ b/BlazorIW/Program.cs
@@ -52,6 +52,7 @@ builder.Services.AddScoped<FileService>();
 builder.Services.AddScoped<BrowserStorageService>();
 builder.Services.AddScoped<LocalizationService>();
 builder.Services.AddScoped<WordPressService>();
+builder.Services.AddScoped<HtmlContentService>();
 
 var app = builder.Build();
 


### PR DESCRIPTION
## Summary
- add HtmlContentService registration in the server Program

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684895ff39048322818ccf8b7aee7f6d