### PR TITLE
Improve WordPress exists check

### DIFF
--- a/BlazorIW.Client/Pages/WordPress.razor
+++ b/BlazorIW.Client/Pages/WordPress.razor
@@ -69,7 +69,7 @@ else if (posts != null)
                     var title = p.GetProperty("title").GetProperty("rendered").GetString() ?? string.Empty;
                     var json = JsonSerializer.Serialize(p, new JsonSerializerOptions { WriteIndented = true });
                     <tr>
-                        <td>@(existingTitles.Contains(title) ? "✔" : string.Empty)</td>
+                        <td>@(existingTitles.Contains(title.Trim()) ? "✔" : "✖")</td>
                         <td><pre>@json</pre></td>
                     </tr>
                 }

--- a/BlazorIW.Client/Services/HtmlContentService.cs
+++ b/BlazorIW.Client/Services/HtmlContentService.cs
@@ -18,11 +18,13 @@ public class HtmlContentService(HttpClient httpClient, NavigationManager navigat
         try
         {
             var titles = await _httpClient.GetFromJsonAsync<List<string>>("api/html-content-titles");
-            return titles is null ? new HashSet<string>() : new HashSet<string>(titles);
+            return titles is null
+                ? new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+                : new HashSet<string>(titles.Select(t => t.Trim()), StringComparer.OrdinalIgnoreCase);
         }
         catch
         {
-            return new HashSet<string>();
+            return new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         }
     }
 


### PR DESCRIPTION
## Summary
- handle title comparison with trimming and ignoring case
- show a ❌ when a WordPress article doesn't exist as HTMLContent

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6848a654add48322934bebd87a5c04be