### PR TITLE
Fix WordPress download post

### DIFF
--- a/BlazorIW/Program.cs
+++ b/BlazorIW/Program.cs
@@ -274,7 +274,7 @@ app.MapPost("/api/import-html-content", async (ApplicationDbContext db, IEnumera
     }
 
     return Results.Json(new { added });
-});
+}).DisableAntiforgery();
 
 app.MapGet("/api/files", (WebRootFileService service) => Results.Json(service.GetFiles().ToList()));
 


### PR DESCRIPTION
## Summary
- disable anti-forgery for the import HTML content endpoint so WordPress post downloads succeed

## Testing
- `./scripts/test.sh` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848a996461c83229de9ccb12737efc7