### PR TITLE
Fix date parsing for HTML import

### DIFF
--- a/BlazorIW/Program.cs
+++ b/BlazorIW/Program.cs
@@ -260,7 +260,9 @@ app.MapPost("/api/import-html-content", async (ILogger<Program> logger, Applicat
             continue;
         }
 
-        var date = DateTime.TryParse(p.Date, out var d) ? d : DateTime.UtcNow;
+        var date = DateTimeOffset.TryParse(p.Date, out var dto)
+            ? dto.UtcDateTime
+            : DateTime.UtcNow;
         db.HtmlContents.Add(new HtmlContentRevision
         {
             Id = Guid.NewGuid(),


### PR DESCRIPTION
## Summary
- parse imported post dates using `DateTimeOffset` and convert them to UTC

## Testing
- `dotnet test --no-build` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6848ae0c408c8322907d118e09615fa2