### PR TITLE
Add Titles page to list HTML content entries

### DIFF
--- a/BlazorIW.Client/Layout/NavMenu.razor
+++ b/BlazorIW.Client/Layout/NavMenu.razor
@@ -48,6 +48,12 @@
         </div>
 
         <div class="nav-item px-3">
+            <NavLink class="nav-link" href="titles">
+                <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Titles
+            </NavLink>
+        </div>
+
+        <div class="nav-item px-3">
             <NavLink class="nav-link" href="d3">
                 <span class="bi bi-diagram-3-nav-menu" aria-hidden="true"></span> D3 Demo
             </NavLink>

--- a/BlazorIW.Client/Pages/Titles.razor
+++ b/BlazorIW.Client/Pages/Titles.razor
@@ -1,0 +1,49 @@
+@page "/titles"
+
+<PageTitle>Titles</PageTitle>
+
+@inject HtmlContentService HtmlSvc
+
+<h1>Titles</h1>
+
+@if (items == null)
+{
+    <p><em>Loading...</em></p>
+}
+else if (items.Count == 0)
+{
+    <p>No entries found.</p>
+}
+else
+{
+    <table class="table">
+        <thead>
+            <tr>
+                <th>Date</th>
+                <th>Title</th>
+                <th>Excerpt</th>
+                <th>Published</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach (var item in items)
+            {
+                <tr>
+                    <td>@item.Date.ToString("yyyy-MM-dd")</td>
+                    <td>@item.Title</td>
+                    <td>@((MarkupString)item.Excerpt)</td>
+                    <td>@item.IsPublished</td>
+                </tr>
+            }
+        </tbody>
+    </table>
+}
+
+@code {
+    private List<HtmlContentDto>? items;
+
+    protected override async Task OnInitializedAsync()
+    {
+        items = await HtmlSvc.GetAllAsync();
+    }
+}

--- a/BlazorIW.Client/Services/HtmlContentService.cs
+++ b/BlazorIW.Client/Services/HtmlContentService.cs
@@ -49,7 +49,29 @@ public class HtmlContentService(HttpClient httpClient, NavigationManager navigat
         _logger.LogInformation("Import returned {Added} added posts", added);
         return added;
     }
+
+    public async Task<List<HtmlContentDto>> GetAllAsync()
+    {
+        if (_httpClient.BaseAddress is null)
+        {
+            _httpClient.BaseAddress = new Uri(_navigationManager.BaseUri);
+        }
+
+        _logger.LogInformation("Requesting all html content from {BaseAddress}", _httpClient.BaseAddress);
+
+        try
+        {
+            var items = await _httpClient.GetFromJsonAsync<List<HtmlContentDto>>("api/html-contents");
+            return items ?? new List<HtmlContentDto>();
+        }
+        catch
+        {
+            _logger.LogError("Failed to fetch html contents");
+            return new List<HtmlContentDto>();
+        }
+    }
 }
 
 public record ImportPostDto(string Date, string Title, string Excerpt, string Content);
 public record ImportResult(int Added);
+public record HtmlContentDto(Guid Id, int Revision, DateTime Date, string Title, string Excerpt, string Content, bool IsReviewRequested, bool IsPublished);

--- a/BlazorIW/Program.cs
+++ b/BlazorIW/Program.cs
@@ -243,6 +243,14 @@ app.MapGet("/api/html-content-titles", async (ApplicationDbContext db, Cancellat
     return Results.Json(titles);
 });
 
+app.MapGet("/api/html-contents", async (ApplicationDbContext db, CancellationToken ct) =>
+{
+    var items = await db.HtmlContents
+        .Select(h => new HtmlContentDto(h.Id, h.Revision, h.Date, h.Title, h.Excerpt, h.Content, h.IsReviewRequested, h.IsPublished))
+        .ToListAsync(ct);
+    return Results.Json(items);
+});
+
 app.MapPost("/api/import-html-content", async (ILogger<Program> logger, ApplicationDbContext db, [FromBody] List<ImportPostDto> posts, CancellationToken ct) =>
 {
     logger.LogInformation("Received import request for {Count} posts", posts.Count);
@@ -292,4 +300,5 @@ app.MapGet("/api/files", (WebRootFileService service) => Results.Json(service.Ge
 app.Run();
 
 record ImportPostDto(string Date, string Title, string Excerpt, string Content);
+record HtmlContentDto(Guid Id, int Revision, DateTime Date, string Title, string Excerpt, string Content, bool IsReviewRequested, bool IsPublished);
 


### PR DESCRIPTION
## Summary
- add `/api/html-contents` endpoint and DTO on server
- extend `HtmlContentService` with GetAllAsync()
- create Titles.razor page showing table of HTML content
- link Titles page from sidebar

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848afb3d8ec83228e0c16c02560f140