### PR TITLE
Add admin-only status change for html content

### DIFF
--- a/BlazorIW.Client/Pages/Titles.razor
+++ b/BlazorIW.Client/Pages/Titles.razor
@@ -42,6 +42,14 @@ else
                             </div>
                             <button class="btn btn-sm btn-secondary me-1" @onclick="() => ShowFull(item.Id)">Show Full</button>
                         }
+                        <div class="mb-2">Status: @GetStatusValue(item)</div>
+                        <AuthorizeView Roles="admin">
+                            <select class="form-select form-select-sm w-auto mb-2" value="@GetStatusValue(item)" @onchange="async e => await ChangeStatusAsync(item, e.Value?.ToString())">
+                                <option value="Draft">Draft</option>
+                                <option value="Review">Review</option>
+                                <option value="Published">Published</option>
+                            </select>
+                        </AuthorizeView>
                         <button class="btn btn-sm btn-outline-secondary" @onclick="() => Collapse(item.Id)">Collapse</button>
                     }
                 </div>
@@ -103,6 +111,28 @@ else
             state.Expanded = false;
             state.ShowFull = false;
         }
+    }
+
+    private static string GetStatusValue(HtmlContentDto item)
+        => item.IsPublished ? "Published" : item.IsReviewRequested ? "Review" : "Draft";
+
+    private async Task ChangeStatusAsync(HtmlContentDto item, string? value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return;
+        }
+
+        var status = value switch
+        {
+            "Published" => HtmlContentStatus.Published,
+            "Review" => HtmlContentStatus.Review,
+            _ => HtmlContentStatus.Draft
+        };
+
+        await HtmlSvc.SetStatusAsync(item.Id, item.Revision, status);
+        item.IsPublished = status == HtmlContentStatus.Published;
+        item.IsReviewRequested = status == HtmlContentStatus.Review;
     }
 
     private class ItemState

--- a/BlazorIW.Client/Services/HtmlContentService.cs
+++ b/BlazorIW.Client/Services/HtmlContentService.cs
@@ -70,8 +70,28 @@ public class HtmlContentService(HttpClient httpClient, NavigationManager navigat
             return new List<HtmlContentDto>();
         }
     }
+
+    public async Task SetStatusAsync(Guid id, int revision, HtmlContentStatus status)
+    {
+        if (_httpClient.BaseAddress is null)
+        {
+            _httpClient.BaseAddress = new Uri(_navigationManager.BaseUri);
+        }
+
+        var dto = new UpdateStatusDto(id, revision, status.ToString());
+        var response = await _httpClient.PostAsJsonAsync("api/html-content-status", dto);
+        response.EnsureSuccessStatusCode();
+    }
 }
 
 public record ImportPostDto(string Date, string Title, string Excerpt, string Content);
 public record ImportResult(int Added);
 public record HtmlContentDto(Guid Id, int Revision, DateTime Date, string Title, string Excerpt, string Content, bool IsReviewRequested, bool IsPublished);
+public record UpdateStatusDto(Guid Id, int Revision, string Status);
+
+public enum HtmlContentStatus
+{
+    Draft,
+    Review,
+    Published
+}


### PR DESCRIPTION
## Summary
- allow admins to change html content status
- add SetStatus API and client call
- show and edit status in Titles page

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848bbb827508322835280b4b0212d58