### PR TITLE
Fix compile issues in UserManagement page

### DIFF
--- a/BlazorIW.Client/Pages/UserManagement.razor
+++ b/BlazorIW.Client/Pages/UserManagement.razor
@@ -38,11 +38,11 @@ else
                 {
                     if (u.Roles.Contains("admin"))
                     {
-                        <button class="btn btn-sm btn-secondary me-1" @onclick="() => ChangeRoleAsync(u, "editor")">Demote to Editor</button>
+                        <button class="btn btn-sm btn-secondary me-1" @onclick="@(() => ChangeRoleAsync(u, \"editor\"))">Demote to Editor</button>
                     }
                     else
                     {
-                        <button class="btn btn-sm btn-secondary me-1" @onclick="() => ChangeRoleAsync(u, "admin")">Promote to Admin</button>
+                        <button class="btn btn-sm btn-secondary me-1" @onclick="@(() => ChangeRoleAsync(u, \"admin\"))">Promote to Admin</button>
                     }
                     if (u.IsDisabled)
                     {
@@ -95,7 +95,7 @@ else
     protected override async Task OnInitializedAsync()
     {
         var authState = await AuthenticationStateTask;
-        currentUserId = authState.User.FindFirstValue(ClaimTypes.NameIdentifier);
+        currentUserId = authState.User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
         await LoadAsync();
     }
 
@@ -120,8 +120,7 @@ else
     private async Task ToggleDisabledAsync(UserInfo user, bool disabled)
     {
         await UserSvc.SetDisabledAsync(user.Id, disabled);
-        user.IsDisabled = disabled;
-        StateHasChanged();
+        await LoadAsync();
     }
 
     private class NewUser


### PR DESCRIPTION
## Summary
- fix quoting in `@onclick` handlers
- use `FindFirst` when retrieving user ID
- reload users after toggling disabled state

## Testing
- `scripts/run.sh` *(fails: dotnet command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848be9fa7e48322ba3b5cdc77cd3add