### PR TITLE
Fix build error by removing custom element registration

### DIFF
--- a/BlazorIW.Client/Program.cs
+++ b/BlazorIW.Client/Program.cs
@@ -1,6 +1,5 @@
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
-using BlazorIW.Client.Pages;
 using BlazorIW.Client.Services;
 
 
@@ -17,7 +16,5 @@ builder.Services.AddScoped<HtmlContentService>();
 builder.Services.AddScoped<LocalizationService>();
 builder.Services.AddScoped<UserService>();
 
-// Register Counter component as custom element <my-counter>
-builder.RootComponents.RegisterCustomElement<Counter>("my-counter");
 
 await builder.Build().RunAsync();


### PR DESCRIPTION
## Summary
- remove reference to pages namespace and custom element registration

## Testing
- `./scripts/run.sh` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6848bfa2b77083229fc6b374bcb0f229