### PR TITLE
Add admin user list page

### DIFF
--- a/BlazorIW.Client/Layout/NavMenu.razor
+++ b/BlazorIW.Client/Layout/NavMenu.razor
@@ -74,6 +74,13 @@
         {
             <AuthorizeView>
                 <Authorized>
+                    <AuthorizeView Roles="admin">
+                        <div class="nav-item px-3">
+                            <NavLink class="nav-link" href="Account/Admin/Users">
+                                <span class="bi bi-person-gear-nav-menu" aria-hidden="true"></span> Admin
+                            </NavLink>
+                        </div>
+                    </AuthorizeView>
                     <div class="nav-item px-3">
                         <NavLink class="nav-link" href="Account/Manage">
                             <span class="bi bi-person-fill-nav-menu" aria-hidden="true"></span> @context.User.Identity?.Name

--- a/BlazorIW/Components/Account/Pages/Admin/Users.razor
+++ b/BlazorIW/Components/Account/Pages/Admin/Users.razor
@@ -1,0 +1,47 @@
+@page "/Account/Admin/Users"
+@using Microsoft.AspNetCore.Identity
+@using Microsoft.EntityFrameworkCore
+@using BlazorIW.Data
+@inject UserManager<ApplicationUser> UserManager
+
+<PageTitle>User List</PageTitle>
+
+<h3>Users</h3>
+
+@if (users is null)
+{
+    <p>Loading...</p>
+}
+else if (!users.Any())
+{
+    <p>No users found.</p>
+}
+else
+{
+    <table class="table">
+        <thead>
+            <tr>
+                <th>User Name</th>
+                <th>Email</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach (var user in users)
+            {
+                <tr>
+                    <td>@user.UserName</td>
+                    <td>@user.Email</td>
+                </tr>
+            }
+        </tbody>
+    </table>
+}
+
+@code {
+    private List<ApplicationUser>? users;
+
+    protected override async Task OnInitializedAsync()
+    {
+        users = await UserManager.Users.ToListAsync();
+    }
+}

--- a/BlazorIW/Components/Account/Pages/Admin/_Imports.razor
+++ b/BlazorIW/Components/Account/Pages/Admin/_Imports.razor
@@ -1,0 +1,2 @@
+@layout AdminLayout
+@attribute [Microsoft.AspNetCore.Authorization.Authorize(Roles="admin")]

--- a/BlazorIW/Components/Account/Shared/AdminLayout.razor
+++ b/BlazorIW/Components/Account/Shared/AdminLayout.razor
@@ -1,0 +1,17 @@
+@inherits LayoutComponentBase
+@layout BlazorIW.Client.Layout.MainLayout
+
+<h1>Administration</h1>
+
+<div>
+    <h2>Account management</h2>
+    <hr />
+    <div class="row">
+        <div class="col-lg-3">
+            <AdminNavMenu />
+        </div>
+        <div class="col-lg-9">
+            @Body
+        </div>
+    </div>
+</div>

--- a/BlazorIW/Components/Account/Shared/AdminNavMenu.razor
+++ b/BlazorIW/Components/Account/Shared/AdminNavMenu.razor
@@ -1,0 +1,5 @@
+<ul class="nav nav-pills flex-column">
+    <li class="nav-item">
+        <NavLink class="nav-link" href="Account/Admin/Users">Users</NavLink>
+    </li>
+</ul>


### PR DESCRIPTION
## Summary
- add AdminLayout and AdminNavMenu
- add Users page under Account/Admin
- show Admin link for admins in NavMenu

## Testing
- `scripts/test.sh` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848c5a728d08322ad9b24e37cc88fd6