### PR TITLE
Fix AuthorizeView context conflict

### DIFF
--- a/BlazorIW.Client/Layout/NavMenu.razor
+++ b/BlazorIW.Client/Layout/NavMenu.razor
@@ -74,7 +74,7 @@
         </div>
         @if (NavigationManager.Uri.Contains("/Account", StringComparison.OrdinalIgnoreCase) || isAuthenticated)
         {
-            <AuthorizeView>
+            <AuthorizeView Context="authState">
                 <Authorized>
                     <AuthorizeView Roles="admin">
                         <div class="nav-item px-3">
@@ -85,7 +85,7 @@
                     </AuthorizeView>
                     <div class="nav-item px-3">
                         <NavLink class="nav-link" href="Account/Manage">
-                            <span class="bi bi-person-fill-nav-menu" aria-hidden="true"></span> @context.User.Identity?.Name
+                            <span class="bi bi-person-fill-nav-menu" aria-hidden="true"></span> @authState.User.Identity?.Name
                         </NavLink>
                     </div>
                     <div class="nav-item px-3">


### PR DESCRIPTION
## Summary
- specify a context name for the outer `AuthorizeView` in `NavMenu`

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848c73ac4488322a09dabaeded2ffb7