### PR TITLE
Fix quoting in admin user role forms

### DIFF
--- a/BlazorIW/Components/Account/Pages/Admin/Users.razor
+++ b/BlazorIW/Components/Account/Pages/Admin/Users.razor
@@ -70,14 +70,14 @@ else
                             <div class="btn-group" role="group">
                                 @if (info.Role == "admin")
                                 {
-                                    <form method="post" @onsubmit="() => ChangeRoleAsync(info, "editor")" style="display:inline">
+                                    <form method="post" @onsubmit="@(() => ChangeRoleAsync(info, \"editor\"))" style="display:inline">
                                         <AntiforgeryToken />
                                         <button type="submit" class="btn btn-sm btn-secondary">Demote</button>
                                     </form>
                                 }
                                 else
                                 {
-                                    <form method="post" @onsubmit="() => ChangeRoleAsync(info, "admin")" style="display:inline">
+                                    <form method="post" @onsubmit="@(() => ChangeRoleAsync(info, \"admin\"))" style="display:inline">
                                         <AntiforgeryToken />
                                         <button type="submit" class="btn btn-sm btn-secondary">Promote</button>
                                     </form>


### PR DESCRIPTION
## Summary
- fix quoting in `Users.razor` role-change forms so the file compiles

## Testing
- `dotnet --version` *(fails: command not found)*
- `scripts/run.sh` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848cbd11a048322a9f1940103d41ab3