### PR TITLE
Fix missing form names in user admin page

### DIFF
--- a/BlazorIW/Components/Account/Pages/Admin/Users.razor
+++ b/BlazorIW/Components/Account/Pages/Admin/Users.razor
@@ -71,7 +71,7 @@ else
                             <div class="btn-group" role="group">
                                 @if (info.Role == "admin")
                                 {
-                                    <form method="post" @onsubmit='() => ChangeRoleAsync(info, "editor")' style="display:inline">
+                                <form method="post" @formname=$"demote-@info.User.Id" @onsubmit='() => ChangeRoleAsync(info, "editor")' style="display:inline">
                                         <AntiforgeryToken />
                                         <button type="submit" class="btn btn-sm btn-secondary">
                                             Demote
@@ -80,7 +80,7 @@ else
                                 }
                                 else
                                 {
-                                    <form method="post" @onsubmit='() => ChangeRoleAsync(info, "admin")' style="display:inline">
+                                <form method="post" @formname=$"promote-@info.User.Id" @onsubmit='() => ChangeRoleAsync(info, "admin")' style="display:inline">
                                         <AntiforgeryToken />
                                         <button type="submit" class="btn btn-sm btn-secondary">
                                             Promote
@@ -88,7 +88,7 @@ else
                                     </form>
                                 }
 
-                                <form method="post" @onsubmit='() => ToggleDisableAsync(info)' style="display:inline">
+                                <form method="post" @formname=$"toggle-disable-@info.User.Id" @onsubmit='() => ToggleDisableAsync(info)' style="display:inline">
                                     <AntiforgeryToken />
                                     <button type="submit" class='btn btn-sm @(info.IsDisabled ? "btn-success" : "btn-danger")'>
                                         @(info.IsDisabled ? "Enable" : "Disable")


### PR DESCRIPTION
## Summary
- supply `@formname` values for change role and disable actions

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848ce1b5cb88322b00b799e89ae4d49