### PR TITLE
Add Razor attribute quoting warning

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,3 +5,12 @@ This repository is primarily a .NET Blazor project. The `package.json` in the re
 ## EF Core Migrations
 
 Codex should **not** modify any Entity Framework migration files. Those files live in `BlazorIW/Migrations`. If migrations appear out of date or missing, do not attempt to regenerate them. They will be handled manually outside of Codex.
+
+## Razor attribute quoting
+
+When editing Razor components, do not mix double quotes for the attribute value and the inner C# string literal. Use single quotes around the attribute or escape the inner quotes to avoid syntax errors. Example:
+
+```razor
+<button @onclick='() => ChangeRoleAsync(u, "editor")'>...</button>
+```
+


### PR DESCRIPTION
## Summary
- document quoting pitfalls in Razor in AGENTS.md

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848ce70a52883229121040ce22cfdc7