### PR TITLE
Fix demote form crash on Users admin page

### DIFF
--- a/BlazorIW/Components/Account/Pages/Admin/Users.razor
+++ b/BlazorIW/Components/Account/Pages/Admin/Users.razor
@@ -142,6 +142,7 @@ else
 
     protected override async Task OnInitializedAsync()
     {
+        NewUser ??= new();
         await RefreshUsersAsync();
     }
 


### PR DESCRIPTION
## Summary
- ensure `NewUser` model is not null when admin page posts

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848d0339a148322bff5c0f2457b5114