### PR TITLE
Add postal code service seeded at startup

### DIFF
--- a/BlazorIW/Data/ApplicationDbContext.cs
+++ b/BlazorIW/Data/ApplicationDbContext.cs
@@ -8,6 +8,7 @@ public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options
     public DbSet<BackgroundVideo> BackgroundVideos => Set<BackgroundVideo>();
     public DbSet<HtmlContentRevision> HtmlContents => Set<HtmlContentRevision>();
     public DbSet<BranchOfficeContent> BranchOfficeContents => Set<BranchOfficeContent>();
+    public DbSet<PostalCode> PostalCodes => Set<PostalCode>();
 
     protected override void OnModelCreating(ModelBuilder builder)
     {
@@ -21,5 +22,7 @@ public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options
             .HasIndex(h => new { h.Id, h.IsPublished })
             .IsUnique()
             .HasFilter("\"IsPublished\" = TRUE");
+
+        builder.Entity<PostalCode>().HasKey(p => p.Zipcode);
     }
 }

--- a/BlazorIW/Data/DataSeeder.cs
+++ b/BlazorIW/Data/DataSeeder.cs
@@ -75,6 +75,18 @@ public static class DataSeeder
         await db.SaveChangesAsync(cancellationToken);
     }
 
+    public static async Task SeedPostalCodesAsync(IServiceProvider services, CancellationToken cancellationToken = default)
+    {
+        using var scope = services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        if (await db.PostalCodes.AnyAsync(cancellationToken))
+            return;
+
+        db.PostalCodes.AddRange(PostalCodeSeedData.Data);
+        await db.SaveChangesAsync(cancellationToken);
+    }
+
     public static async Task SeedDefaultUsersAsync(IServiceProvider services, string password, CancellationToken cancellationToken = default)
     {
         using var scope = services.CreateScope();

--- a/BlazorIW/Data/PostalCode.cs
+++ b/BlazorIW/Data/PostalCode.cs
@@ -1,0 +1,8 @@
+namespace BlazorIW.Data;
+
+public class PostalCode
+{
+    public string Zipcode { get; set; } = string.Empty;
+    public double Latitude { get; set; }
+    public double Longitude { get; set; }
+}

--- a/BlazorIW/Data/PostalCodeSeedData.cs
+++ b/BlazorIW/Data/PostalCodeSeedData.cs
@@ -1,0 +1,43 @@
+namespace BlazorIW.Data;
+
+public static class PostalCodeSeedData
+{
+    public static readonly PostalCode[] Data = new[]
+    {
+        new PostalCode { Zipcode = "231-0045", Latitude = 35.4465, Longitude = 139.6325 },
+        new PostalCode { Zipcode = "210-0814", Latitude = 35.5303, Longitude = 139.7327 },
+        new PostalCode { Zipcode = "210-0833", Latitude = 35.5210, Longitude = 139.7238 },
+        new PostalCode { Zipcode = "211-0051", Latitude = 35.5902, Longitude = 139.6421 },
+        new PostalCode { Zipcode = "213-0032", Latitude = 35.6122, Longitude = 139.6022 },
+        new PostalCode { Zipcode = "226-0016", Latitude = 35.5047, Longitude = 139.5481 },
+        new PostalCode { Zipcode = "226-0029", Latitude = 35.5093, Longitude = 139.5330 },
+        new PostalCode { Zipcode = "227-0036", Latitude = 35.5621, Longitude = 139.4828 },
+        new PostalCode { Zipcode = "230-0001", Latitude = 35.5335, Longitude = 139.6796 },
+        new PostalCode { Zipcode = "231-0026", Latitude = 35.4438, Longitude = 139.6456 },
+        new PostalCode { Zipcode = "238-0224", Latitude = 35.1488, Longitude = 139.6305 },
+        new PostalCode { Zipcode = "240-0026", Latitude = 35.4436, Longitude = 139.5932 },
+        new PostalCode { Zipcode = "240-0067", Latitude = 35.4734, Longitude = 139.5909 },
+        new PostalCode { Zipcode = "243-0402", Latitude = 35.4632, Longitude = 139.4120 },
+        new PostalCode { Zipcode = "244-0003", Latitude = 35.3911, Longitude = 139.5273 },
+        new PostalCode { Zipcode = "245-0014", Latitude = 35.4063, Longitude = 139.5096 },
+        new PostalCode { Zipcode = "245-0061", Latitude = 35.3991, Longitude = 139.5146 },
+        new PostalCode { Zipcode = "245-0062", Latitude = 35.3911, Longitude = 139.5178 },
+        new PostalCode { Zipcode = "251-0035", Latitude = 35.3134, Longitude = 139.4866 },
+        new PostalCode { Zipcode = "251-0043", Latitude = 35.3308, Longitude = 139.4467 },
+        new PostalCode { Zipcode = "251-0047", Latitude = 35.3308, Longitude = 139.4467 },
+        new PostalCode { Zipcode = "251-0875", Latitude = 35.3554, Longitude = 139.4706 },
+        new PostalCode { Zipcode = "252-0025", Latitude = 35.4739, Longitude = 139.3861 },
+        new PostalCode { Zipcode = "252-0303", Latitude = 35.5315, Longitude = 139.4345 },
+        new PostalCode { Zipcode = "252-0321", Latitude = 35.5172, Longitude = 139.4107 },
+        new PostalCode { Zipcode = "252-0802", Latitude = 35.4128, Longitude = 139.4714 },
+        new PostalCode { Zipcode = "252-0813", Latitude = 35.3784, Longitude = 139.4751 },
+        new PostalCode { Zipcode = "254-0014", Latitude = 35.3601, Longitude = 139.3676 },
+        new PostalCode { Zipcode = "254-0018", Latitude = 35.3578, Longitude = 139.3539 },
+        new PostalCode { Zipcode = "254-0061", Latitude = 35.3451, Longitude = 139.3292 },
+        new PostalCode { Zipcode = "254-0084", Latitude = 35.3563, Longitude = 139.3293 },
+        new PostalCode { Zipcode = "254-0813", Latitude = 35.3176, Longitude = 139.3506 },
+        new PostalCode { Zipcode = "254-0906", Latitude = 35.3464, Longitude = 139.3016 },
+        new PostalCode { Zipcode = "259-1205", Latitude = 35.3429, Longitude = 139.2550 },
+        new PostalCode { Zipcode = "258-0017", Latitude = 35.3194, Longitude = 139.1504 }
+    };
+}

--- a/BlazorIW/Program.cs
+++ b/BlazorIW/Program.cs
@@ -54,6 +54,7 @@ builder.Services.AddScoped<BrowserStorageService>();
 builder.Services.AddScoped<LocalizationService>();
 builder.Services.AddScoped<WordPressService>();
 builder.Services.AddScoped<HtmlContentService>();
+builder.Services.AddScoped<PostalCodeService>();
 
 var app = builder.Build();
 
@@ -72,6 +73,7 @@ using (var scope = app.Services.CreateScope())
         DataSeeder.SeedBackgroundVideosAsync(scope.ServiceProvider).GetAwaiter().GetResult();
         DataSeeder.SeedHtmlContentsAsync(scope.ServiceProvider).GetAwaiter().GetResult();
         DataSeeder.SeedBranchOfficeContentsAsync(scope.ServiceProvider).GetAwaiter().GetResult();
+        DataSeeder.SeedPostalCodesAsync(scope.ServiceProvider).GetAwaiter().GetResult();
         DataSeeder.SeedDefaultUsersAsync(scope.ServiceProvider, defaultUserPassword).GetAwaiter().GetResult();
 }
 

--- a/BlazorIW/Services/PostalCodeService.cs
+++ b/BlazorIW/Services/PostalCodeService.cs
@@ -1,0 +1,22 @@
+using BlazorIW.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace BlazorIW.Services;
+
+public class PostalCodeService(ApplicationDbContext db)
+{
+    private readonly ApplicationDbContext _db = db;
+
+    public async Task<(double Latitude, double Longitude)> GetLatLongAsync(string zipcode, CancellationToken ct = default)
+    {
+        var code = await _db.PostalCodes.FirstOrDefaultAsync(p => p.Zipcode == zipcode, ct);
+        if (code is null)
+        {
+            code = await _db.PostalCodes.FirstOrDefaultAsync(p => p.Zipcode == "231-0045", ct);
+        }
+
+        return code is null
+            ? (35.4465, 139.6325)
+            : (code.Latitude, code.Longitude);
+    }
+}


### PR DESCRIPTION
## Summary
- add `PostalCode` entity and database seed data
- register `PostalCodeService`
- seed postal codes during startup
- provide lookup that defaults to postal code 231‑0045

## Testing
- `dotnet test` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848cb294dac8322a16f944190c82d5d