### PR TITLE
Fix logout antiforgery error

### DIFF
--- a/BlazorIW/Components/Account/IdentityComponentsEndpointRouteBuilderExtensions.cs
+++ b/BlazorIW/Components/Account/IdentityComponentsEndpointRouteBuilderExtensions.cs
@@ -47,7 +47,8 @@ internal static class IdentityComponentsEndpointRouteBuilderExtensions
         {
             await signInManager.SignOutAsync();
             return TypedResults.LocalRedirect($"~/{returnUrl}");
-        });
+        })
+        .DisableAntiforgery();
 
         var manageGroup = accountGroup.MapGroup("/Manage").RequireAuthorization();
 


### PR DESCRIPTION
## Summary
- disable antiforgery middleware for the logout endpoint

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848d70fac8c83228539cabdd75a633f