### PR TITLE
Add revision support for BranchOfficeContent

### DIFF
--- a/BlazorIW.Tests/BranchOfficeContentWorkflowTests.cs
+++ b/BlazorIW.Tests/BranchOfficeContentWorkflowTests.cs
@@ -1,0 +1,107 @@
+using System;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using BlazorIW.Data;
+using Xunit;
+using System.Threading.Tasks;
+
+namespace BlazorIW.Tests;
+
+public class BranchOfficeContentWorkflowTests
+{
+    private static SqliteConnection CreateConnection()
+    {
+        var connection = new SqliteConnection("DataSource=:memory:");
+        connection.Open();
+        return connection;
+    }
+
+    private static ApplicationDbContext CreateContext(SqliteConnection connection)
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseSqlite(connection)
+            .Options;
+        var context = new ApplicationDbContext(options);
+        context.Database.EnsureCreated();
+        return context;
+    }
+
+    [Fact]
+    public void Adding_two_published_revisions_fails()
+    {
+        using var connection = CreateConnection();
+        using var context = CreateContext(connection);
+
+        var id = Guid.NewGuid();
+        context.BranchOfficeContents.Add(new BranchOfficeContent
+        {
+            Id = id,
+            Revision = 1,
+            Date = DateTime.UtcNow,
+            BranchName = "A",
+            Address = "A",
+            PostalCode = "1",
+            TelephoneNumber = "1",
+            FaxNumber = "1",
+            Email = "a@example.com",
+            IsPublished = true
+        });
+        context.SaveChanges();
+
+        context.BranchOfficeContents.Add(new BranchOfficeContent
+        {
+            Id = id,
+            Revision = 2,
+            Date = DateTime.UtcNow,
+            BranchName = "B",
+            Address = "B",
+            PostalCode = "2",
+            TelephoneNumber = "2",
+            FaxNumber = "2",
+            Email = "b@example.com",
+            IsPublished = true
+        });
+
+        Assert.Throws<DbUpdateException>(() => context.SaveChanges());
+    }
+
+    [Fact]
+    public void Review_request_flag_is_unique_per_content()
+    {
+        using var connection = CreateConnection();
+        using var context = CreateContext(connection);
+
+        var id = Guid.NewGuid();
+        context.BranchOfficeContents.Add(new BranchOfficeContent { Id = id, Revision = 1, Date = DateTime.UtcNow, BranchName = "R1", Address = "R1", PostalCode = "1", TelephoneNumber = "1", FaxNumber = "1", Email = "r1@example.com" });
+        context.SaveChanges();
+
+        var rev2 = new BranchOfficeContent { Id = id, Revision = 2, Date = DateTime.UtcNow, BranchName = "R2", Address = "R2", PostalCode = "2", TelephoneNumber = "2", FaxNumber = "2", Email = "r2@example.com", IsReviewRequested = true };
+        context.BranchOfficeContents.Add(rev2);
+        context.SaveChanges();
+
+        context.BranchOfficeContents.Add(new BranchOfficeContent { Id = id, Revision = 3, Date = DateTime.UtcNow, BranchName = "R3", Address = "R3", PostalCode = "3", TelephoneNumber = "3", FaxNumber = "3", Email = "r3@example.com", IsReviewRequested = true });
+
+        Assert.Throws<DbUpdateException>(() => context.SaveChanges());
+    }
+
+    [Fact]
+    public async Task Can_request_review_after_clearing_previous()
+    {
+        using var connection = CreateConnection();
+        using var context = CreateContext(connection);
+
+        var id = Guid.NewGuid();
+        context.BranchOfficeContents.Add(new BranchOfficeContent { Id = id, Revision = 1, Date = DateTime.UtcNow, BranchName = "R1", Address = "R1", PostalCode = "1", TelephoneNumber = "1", FaxNumber = "1", Email = "r1@example.com" });
+        var rev2 = new BranchOfficeContent { Id = id, Revision = 2, Date = DateTime.UtcNow, BranchName = "R2", Address = "R2", PostalCode = "2", TelephoneNumber = "2", FaxNumber = "2", Email = "r2@example.com", IsReviewRequested = true };
+        context.BranchOfficeContents.Add(rev2);
+        context.SaveChanges();
+
+        rev2.IsReviewRequested = false;
+        context.SaveChanges();
+
+        context.BranchOfficeContents.Add(new BranchOfficeContent { Id = id, Revision = 3, Date = DateTime.UtcNow, BranchName = "R3", Address = "R3", PostalCode = "3", TelephoneNumber = "3", FaxNumber = "3", Email = "r3@example.com", IsReviewRequested = true });
+        context.SaveChanges();
+
+        Assert.Equal(3, await context.BranchOfficeContents.CountAsync());
+    }
+}

--- a/BlazorIW/Data/ApplicationDbContext.cs
+++ b/BlazorIW/Data/ApplicationDbContext.cs
@@ -23,6 +23,16 @@ public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options
             .IsUnique()
             .HasFilter("\"IsPublished\" = TRUE");
 
+        builder.Entity<BranchOfficeContent>().HasKey(b => new { b.Id, b.Revision });
+        builder.Entity<BranchOfficeContent>()
+            .HasIndex(b => new { b.Id, b.IsReviewRequested })
+            .IsUnique()
+            .HasFilter("\"IsReviewRequested\" = TRUE");
+        builder.Entity<BranchOfficeContent>()
+            .HasIndex(b => new { b.Id, b.IsPublished })
+            .IsUnique()
+            .HasFilter("\"IsPublished\" = TRUE");
+
         builder.Entity<PostalCode>().HasKey(p => p.Zipcode);
     }
 }

--- a/BlazorIW/Data/BranchOfficeContent.cs
+++ b/BlazorIW/Data/BranchOfficeContent.cs
@@ -3,5 +3,14 @@ namespace BlazorIW.Data;
 public class BranchOfficeContent : IContent
 {
     public Guid Id { get; init; } = Guid.NewGuid();
+    public int Revision { get; set; } = 1;
+    public DateTime Date { get; set; }
+    public string BranchName { get; set; } = string.Empty;
     public string Address { get; set; } = string.Empty;
+    public string PostalCode { get; set; } = string.Empty;
+    public string TelephoneNumber { get; set; } = string.Empty;
+    public string FaxNumber { get; set; } = string.Empty;
+    public string Email { get; set; } = string.Empty;
+    public bool IsReviewRequested { get; set; }
+    public bool IsPublished { get; set; }
 }

--- a/BlazorIW/Data/DataSeeder.cs
+++ b/BlazorIW/Data/DataSeeder.cs
@@ -69,7 +69,15 @@ public static class DataSeeder
 
         db.BranchOfficeContents.Add(new BranchOfficeContent
         {
-            Address = "123 Main St"
+            Revision = 1,
+            Date = DateTime.UtcNow,
+            BranchName = "Headquarters",
+            Address = "123 Main St",
+            PostalCode = "00000",
+            TelephoneNumber = "123-456-7890",
+            FaxNumber = "123-456-7891",
+            Email = "info@example.com",
+            IsPublished = true
         });
 
         await db.SaveChangesAsync(cancellationToken);


### PR DESCRIPTION
## Summary
- expand `BranchOfficeContent` with contact details and revision fields
- enforce uniqueness for published/reviewed branch office revisions
- seed an initial BranchOfficeContent entry
- add new workflow tests for BranchOfficeContent

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848dd2cb9f08322b2fa9c23802e26bb