### PR TITLE
Add localization resources

### DIFF
--- a/BlazorIW/Components/Account/Pages/Login.razor
+++ b/BlazorIW/Components/Account/Pages/Login.razor
@@ -9,47 +9,48 @@
 @inject ILogger<Login> Logger
 @inject NavigationManager NavigationManager
 @inject IdentityRedirectManager RedirectManager
+@inject Microsoft.Extensions.Localization.IStringLocalizer<Login> L
 
-<PageTitle>Log in</PageTitle>
+<PageTitle>@L["Log in"]</PageTitle>
 
-<h1>Log in</h1>
+<h1>@L["Log in"]</h1>
 <div class="row">
     <div class="col-lg-6">
         <section>
             <StatusMessage Message="@errorMessage" />
             <EditForm Model="Input" method="post" OnValidSubmit="LoginUser" FormName="login">
                 <DataAnnotationsValidator />
-                <h2>Use a local account to log in.</h2>
+                <h2>@L["Use a local account to log in."]</h2>
                 <hr />
                 <ValidationSummary class="text-danger" role="alert" />
                 <div class="form-floating mb-3">
                     <InputText @bind-Value="Input.Email" id="Input.Email" class="form-control" autocomplete="username" aria-required="true" placeholder="name@example.com" />
-                    <label for="Input.Email" class="form-label">Email</label>
+                    <label for="Input.Email" class="form-label">@L["Email"]</label>
                     <ValidationMessage For="() => Input.Email" class="text-danger" />
                 </div>
                 <div class="form-floating mb-3">
                     <InputText type="password" @bind-Value="Input.Password" id="Input.Password" class="form-control" autocomplete="current-password" aria-required="true" placeholder="password" />
-                    <label for="Input.Password" class="form-label">Password</label>
+                    <label for="Input.Password" class="form-label">@L["Password"]</label>
                     <ValidationMessage For="() => Input.Password" class="text-danger" />
                 </div>
                 <div class="checkbox mb-3">
                     <label class="form-label">
                         <InputCheckbox @bind-Value="Input.RememberMe" class="darker-border-checkbox form-check-input" />
-                        Remember me
+                        @L["Remember me"]
                     </label>
                 </div>
                 <div>
-                    <button type="submit" class="w-100 btn btn-lg btn-primary">Log in</button>
+                    <button type="submit" class="w-100 btn btn-lg btn-primary">@L["Log in"]</button>
                 </div>
                 <div>
                     <p>
-                        <a href="Account/ForgotPassword">Forgot your password?</a>
+                        <a href="Account/ForgotPassword">@L["Forgot your password?"]</a>
                     </p>
                     <p>
-                        <a href="@(NavigationManager.GetUriWithQueryParameters("Account/Register", new Dictionary<string, object?> { ["ReturnUrl"] = ReturnUrl }))">Register as a new user</a>
+                        <a href="@(NavigationManager.GetUriWithQueryParameters("Account/Register", new Dictionary<string, object?> { ["ReturnUrl"] = ReturnUrl }))">@L["Register as a new user"]</a>
                     </p>
                     <p>
-                        <a href="Account/ResendEmailConfirmation">Resend email confirmation</a>
+                        <a href="Account/ResendEmailConfirmation">@L["Resend email confirmation"]</a>
                     </p>
                 </div>
             </EditForm>
@@ -57,7 +58,7 @@
     </div>
     <div class="col-lg-4 col-lg-offset-2">
         <section>
-            <h3>Use another service to log in.</h3>
+            <h3>@L["Use another service to log in."]</h3>
             <hr />
             <ExternalLoginPicker />
         </section>
@@ -108,7 +109,7 @@
         }
         else
         {
-            errorMessage = "Error: Invalid login attempt.";
+            errorMessage = L["Error: Invalid login attempt."];
         }
     }
 

--- a/BlazorIW/Components/Account/Pages/Register.razor
+++ b/BlazorIW/Components/Account/Pages/Register.razor
@@ -14,40 +14,41 @@
 @inject ILogger<Register> Logger
 @inject NavigationManager NavigationManager
 @inject IdentityRedirectManager RedirectManager
+@inject Microsoft.Extensions.Localization.IStringLocalizer<Register> L
 
-<PageTitle>Register</PageTitle>
+<PageTitle>@L["Register"]</PageTitle>
 
-<h1>Register</h1>
+<h1>@L["Register"]</h1>
 
 <div class="row">
     <div class="col-lg-6">
         <StatusMessage Message="@Message" />
         <EditForm Model="Input" asp-route-returnUrl="@ReturnUrl" method="post" OnValidSubmit="RegisterUser" FormName="register">
             <DataAnnotationsValidator />
-            <h2>Create a new account.</h2>
+            <h2>@L["Create a new account."]</h2>
             <hr />
             <ValidationSummary class="text-danger" role="alert" />
             <div class="form-floating mb-3">
                 <InputText @bind-Value="Input.Email" id="Input.Email" class="form-control" autocomplete="username" aria-required="true" placeholder="name@example.com" />
-                <label for="Input.Email">Email</label>
+                <label for="Input.Email">@L["Email"]</label>
                 <ValidationMessage For="() => Input.Email" class="text-danger" />
             </div>
             <div class="form-floating mb-3">
                 <InputText type="password" @bind-Value="Input.Password" id="Input.Password" class="form-control" autocomplete="new-password" aria-required="true" placeholder="password" />
-                <label for="Input.Password">Password</label>
+                <label for="Input.Password">@L["Password"]</label>
                 <ValidationMessage For="() => Input.Password" class="text-danger" />
             </div>
             <div class="form-floating mb-3">
                 <InputText type="password" @bind-Value="Input.ConfirmPassword" id="Input.ConfirmPassword" class="form-control" autocomplete="new-password" aria-required="true" placeholder="password" />
-                <label for="Input.ConfirmPassword">Confirm Password</label>
+                <label for="Input.ConfirmPassword">@L["Confirm Password"]</label>
                 <ValidationMessage For="() => Input.ConfirmPassword" class="text-danger" />
             </div>
-            <button type="submit" class="w-100 btn btn-lg btn-primary">Register</button>
+            <button type="submit" class="w-100 btn btn-lg btn-primary">@L["Register"]</button>
         </EditForm>
     </div>
     <div class="col-lg-4 col-lg-offset-2">
         <section>
-            <h3>Use another service to register.</h3>
+            <h3>@L["Use another service to register."]</h3>
             <hr />
             <ExternalLoginPicker />
         </section>

--- a/BlazorIW/Program.cs
+++ b/BlazorIW/Program.cs
@@ -8,6 +8,7 @@ using BlazorIW.Services;
 using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage;
 using Microsoft.AspNetCore.Mvc;
 using BlazorIW.Client.Services;
+using Microsoft.AspNetCore.Localization;
 
 const int WaterfallVideoId = 6394054;
 const int GoatVideoId = 30646036;
@@ -16,6 +17,7 @@ var isDatabaseAvailable = true;
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
+builder.Services.AddLocalization(options => options.ResourcesPath = "Resources");
 builder.Services.AddRazorComponents()
     .AddInteractiveWebAssemblyComponents()
     .AddAuthenticationStateSerialization();
@@ -92,6 +94,13 @@ else
 }
 
 app.UseHttpsRedirection();
+
+var supportedCultures = new[] { "en", "ja" };
+var localizationOptions = new RequestLocalizationOptions()
+    .SetDefaultCulture("en")
+    .AddSupportedCultures(supportedCultures)
+    .AddSupportedUICultures(supportedCultures);
+app.UseRequestLocalization(localizationOptions);
 
 // Serve files from wwwroot for environments where MapStaticAssets might not
 // register the middleware correctly (e.g., certain container hosts).

--- a/BlazorIW/Resources/Components/Account/Pages/Login.ja.resx
+++ b/BlazorIW/Resources/Components/Account/Pages/Login.ja.resx
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="Log in" xml:space="preserve">
+    <value>ログイン</value>
+  </data>
+  <data name="Use a local account to log in." xml:space="preserve">
+    <value>ローカルアカウントでログインします。</value>
+  </data>
+  <data name="Email" xml:space="preserve">
+    <value>メールアドレス</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>パスワード</value>
+  </data>
+  <data name="Remember me" xml:space="preserve">
+    <value>ログイン状態を保持</value>
+  </data>
+  <data name="Forgot your password?" xml:space="preserve">
+    <value>パスワードをお忘れですか？</value>
+  </data>
+  <data name="Register as a new user" xml:space="preserve">
+    <value>新規ユーザー登録</value>
+  </data>
+  <data name="Resend email confirmation" xml:space="preserve">
+    <value>確認メールを再送信</value>
+  </data>
+  <data name="Use another service to log in." xml:space="preserve">
+    <value>別のサービスでログイン</value>
+  </data>
+  <data name="Error: Invalid login attempt." xml:space="preserve">
+    <value>エラー: 無効なログイン試行です。</value>
+  </data>
+</root>

--- a/BlazorIW/Resources/Components/Account/Pages/Login.resx
+++ b/BlazorIW/Resources/Components/Account/Pages/Login.resx
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="Log in" xml:space="preserve">
+    <value>Log in</value>
+  </data>
+  <data name="Use a local account to log in." xml:space="preserve">
+    <value>Use a local account to log in.</value>
+  </data>
+  <data name="Email" xml:space="preserve">
+    <value>Email</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="Remember me" xml:space="preserve">
+    <value>Remember me</value>
+  </data>
+  <data name="Forgot your password?" xml:space="preserve">
+    <value>Forgot your password?</value>
+  </data>
+  <data name="Register as a new user" xml:space="preserve">
+    <value>Register as a new user</value>
+  </data>
+  <data name="Resend email confirmation" xml:space="preserve">
+    <value>Resend email confirmation</value>
+  </data>
+  <data name="Use another service to log in." xml:space="preserve">
+    <value>Use another service to log in.</value>
+  </data>
+  <data name="Error: Invalid login attempt." xml:space="preserve">
+    <value>Error: Invalid login attempt.</value>
+  </data>
+</root>

--- a/BlazorIW/Resources/Components/Account/Pages/Register.ja.resx
+++ b/BlazorIW/Resources/Components/Account/Pages/Register.ja.resx
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="Register" xml:space="preserve">
+    <value>登録</value>
+  </data>
+  <data name="Create a new account." xml:space="preserve">
+    <value>新しいアカウントを作成します。</value>
+  </data>
+  <data name="Email" xml:space="preserve">
+    <value>メールアドレス</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>パスワード</value>
+  </data>
+  <data name="Confirm Password" xml:space="preserve">
+    <value>パスワードの確認</value>
+  </data>
+  <data name="Use another service to register." xml:space="preserve">
+    <value>別のサービスで登録</value>
+  </data>
+</root>

--- a/BlazorIW/Resources/Components/Account/Pages/Register.resx
+++ b/BlazorIW/Resources/Components/Account/Pages/Register.resx
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="Register" xml:space="preserve">
+    <value>Register</value>
+  </data>
+  <data name="Create a new account." xml:space="preserve">
+    <value>Create a new account.</value>
+  </data>
+  <data name="Email" xml:space="preserve">
+    <value>Email</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="Confirm Password" xml:space="preserve">
+    <value>Confirm Password</value>
+  </data>
+  <data name="Use another service to register." xml:space="preserve">
+    <value>Use another service to register.</value>
+  </data>
+</root>


### PR DESCRIPTION
## Summary
- add resx resources for Login and Register identity pages
- inject `IStringLocalizer` into identity pages and use localized strings
- enable localization in Program.cs with `UseRequestLocalization`

## Testing
- `./scripts/test.sh` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848dd6c33a48322bbc1d1a0687a6f6e