### PR TITLE
Add Weather page localization

### DIFF
--- a/BlazorIW.Client/Pages/Weather.razor
+++ b/BlazorIW.Client/Pages/Weather.razor
@@ -1,24 +1,28 @@
 ﻿@page "/weather"
+@using Microsoft.Extensions.Localization
+@inject IStringLocalizer<Weather> L
+@inject LocalizationService Localization
 
-<PageTitle>Weather</PageTitle>
+<PageTitle>@L["Weather"]</PageTitle>
 
-<h1>Weather</h1>
+<h1>@L["Weather"]</h1>
 
-<p>This component demonstrates showing data.</p>
+<p>@L["This component demonstrates showing data."]</p>
+<p>@L["Current Culture"]: @Localization.CurrentCulture.Name</p>
 
 @if (forecasts == null)
 {
-    <p><em>Loading...</em></p>
+    <p><em>@L["Loading..."]</em></p>
 }
 else
 {
     <table class="table">
         <thead>
             <tr>
-                <th>Date</th>
-                <th aria-label="Temperature in Celsius">Temp. (C)</th>
-                <th aria-label="Temperature in Farenheit">Temp. (F)</th>
-                <th>Summary</th>
+                <th>@L["Date"]</th>
+                <th aria-label="@L["Temperature in Celsius"]">@L["Temp. (C)"]</th>
+                <th aria-label="@L["Temperature in Farenheit"]">@L["Temp. (F)"]</th>
+                <th>@L["Summary"]</th>
             </tr>
         </thead>
         <tbody>

--- a/BlazorIW.Client/Program.cs
+++ b/BlazorIW.Client/Program.cs
@@ -6,6 +6,8 @@ using BlazorIW.Client.Services;
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
 
+builder.Services.AddLocalization(options => options.ResourcesPath = "Resources");
+
 builder.Services.AddAuthorizationCore();
 builder.Services.AddCascadingAuthenticationState();
 builder.Services.AddAuthenticationStateDeserialization();

--- a/BlazorIW.Client/Resources/Pages/Weather.ja.resx
+++ b/BlazorIW.Client/Resources/Pages/Weather.ja.resx
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="Weather" xml:space="preserve">
+    <value>天気</value>
+  </data>
+  <data name="This component demonstrates showing data." xml:space="preserve">
+    <value>このコンポーネントはデータの表示を示しています。</value>
+  </data>
+  <data name="Current Culture" xml:space="preserve">
+    <value>現在のカルチャ</value>
+  </data>
+  <data name="Loading..." xml:space="preserve">
+    <value>読み込み中...</value>
+  </data>
+  <data name="Date" xml:space="preserve">
+    <value>日付</value>
+  </data>
+  <data name="Temperature in Celsius" xml:space="preserve">
+    <value>摂氏の温度</value>
+  </data>
+  <data name="Temp. (C)" xml:space="preserve">
+    <value>温度 (C)</value>
+  </data>
+  <data name="Temperature in Farenheit" xml:space="preserve">
+    <value>華氏の温度</value>
+  </data>
+  <data name="Temp. (F)" xml:space="preserve">
+    <value>温度 (F)</value>
+  </data>
+  <data name="Summary" xml:space="preserve">
+    <value>概要</value>
+  </data>
+</root>

--- a/BlazorIW.Client/Resources/Pages/Weather.resx
+++ b/BlazorIW.Client/Resources/Pages/Weather.resx
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="Weather" xml:space="preserve">
+    <value>Weather</value>
+  </data>
+  <data name="This component demonstrates showing data." xml:space="preserve">
+    <value>This component demonstrates showing data.</value>
+  </data>
+  <data name="Current Culture" xml:space="preserve">
+    <value>Current Culture</value>
+  </data>
+  <data name="Loading..." xml:space="preserve">
+    <value>Loading...</value>
+  </data>
+  <data name="Date" xml:space="preserve">
+    <value>Date</value>
+  </data>
+  <data name="Temperature in Celsius" xml:space="preserve">
+    <value>Temperature in Celsius</value>
+  </data>
+  <data name="Temp. (C)" xml:space="preserve">
+    <value>Temp. (C)</value>
+  </data>
+  <data name="Temperature in Farenheit" xml:space="preserve">
+    <value>Temperature in Farenheit</value>
+  </data>
+  <data name="Temp. (F)" xml:space="preserve">
+    <value>Temp. (F)</value>
+  </data>
+  <data name="Summary" xml:space="preserve">
+    <value>Summary</value>
+  </data>
+</root>


### PR DESCRIPTION
## Summary
- localize Weather page for Japanese and English
- show the current culture on the page
- enable localization in the WebAssembly host

## Testing
- `dotnet build BlazorIW.sln -c Release` *(fails: `dotnet` not found)*
- `dotnet test BlazorIW.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848dfeee4e08322bf3a52b6b01ed002