### PR TITLE
Initialize WASM culture at startup

### DIFF
--- a/BlazorIW.Client/Program.cs
+++ b/BlazorIW.Client/Program.cs
@@ -21,4 +21,9 @@ builder.Services.AddScoped<LocalizationService>();
 // Register Counter component as custom element <my-counter>
 builder.RootComponents.RegisterCustomElement<Counter>("my-counter");
 
-await builder.Build().RunAsync();
+var host = builder.Build();
+
+var localization = host.Services.GetRequiredService<LocalizationService>();
+await localization.LoadCultureAsync();
+
+await host.RunAsync();


### PR DESCRIPTION
## Summary
- load the stored culture through `LocalizationService` before running the client app

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848f24d335083229025a578428381a7