### PR TITLE
Fix culture change configuration for Blazor WASM

### DIFF
--- a/BlazorIW.Client/BlazorIW.Client.csproj
+++ b/BlazorIW.Client/BlazorIW.Client.csproj
@@ -6,6 +6,7 @@
     <Nullable>enable</Nullable>
     <NoDefaultLaunchSettingsFile>true</NoDefaultLaunchSettingsFile>
     <StaticWebAssetProjectMode>Default</StaticWebAssetProjectMode>
+    <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- enable full globalization data load so switching cultures at runtime works

## Testing
- ❌ `dotnet format --no-restore` *(failed: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848f59a2a288322b221578c4aa337a0