### PR TITLE
Localize remaining Blazor client pages

### DIFF
--- a/BlazorIW.Client/Pages/Auth.razor
+++ b/BlazorIW.Client/Pages/Auth.razor
@@ -1,13 +1,16 @@
 ﻿@page "/auth"
 
 @using Microsoft.AspNetCore.Authorization
+@using Microsoft.Extensions.Localization
+@inject IStringLocalizer<Auth> L
+@inject LocalizationService Localization
 
 @attribute [Authorize]
 
-<PageTitle>Auth</PageTitle>
+<PageTitle>@L["Auth"]</PageTitle>
 
-<h1>You are authenticated</h1>
+<h1>@L["You are authenticated"]</h1>
 
 <AuthorizeView>
-    Hello @context.User.Identity?.Name!
+    @L["Hello"] @context.User.Identity?.Name!
 </AuthorizeView>

--- a/BlazorIW.Client/Pages/Counter.razor
+++ b/BlazorIW.Client/Pages/Counter.razor
@@ -1,12 +1,15 @@
 ﻿@page "/counter"
+@using Microsoft.Extensions.Localization
+@inject IStringLocalizer<Counter> L
+@inject LocalizationService Localization
 
-<PageTitle>Counter</PageTitle>
+<PageTitle>@L["Counter"]</PageTitle>
 
-<h1>Counter</h1>
+<h1>@L["Counter"]</h1>
 
-<p role="status">Current count: @currentCount</p>
+<p role="status">@L["Current count:"] @currentCount</p>
 
-<button class="btn btn-primary" @onclick="IncrementCount">Click me</button>
+<button class="btn btn-primary" @onclick="IncrementCount">@L["Click me"]</button>
 
 @code {
     private int currentCount = 0;

--- a/BlazorIW.Client/Pages/D3Demo.razor
+++ b/BlazorIW.Client/Pages/D3Demo.razor
@@ -1,15 +1,18 @@
 @page "/d3"
 @rendermode InteractiveWebAssembly
+@using Microsoft.Extensions.Localization
+@inject IStringLocalizer<D3Demo> L
+@inject LocalizationService Localization
 
-<PageTitle>D3 Demo</PageTitle>
+<PageTitle>@L["D3 Demo"]</PageTitle>
 
-<h1>D3 Demo</h1>
+<h1>@L["D3 Demo"]</h1>
 
-<div id="view-toggle" class="btn-group btn-group-toggle mb-2" role="group" aria-label="View mode">
+<div id="view-toggle" class="btn-group btn-group-toggle mb-2" role="group" aria-label="@L["View mode"]">
     <input type="radio" class="btn-check" name="viewOptions" id="listOption" value="list" autocomplete="off">
-    <label class="btn btn-outline-primary" for="listOption">List</label>
+    <label class="btn btn-outline-primary" for="listOption">@L["List"]</label>
     <input type="radio" class="btn-check" name="viewOptions" id="mapOption" value="map" autocomplete="off" checked>
-    <label class="btn btn-outline-primary" for="mapOption">Hex Map</label>
+    <label class="btn btn-outline-primary" for="mapOption">@L["Hex Map"]</label>
 </div>
 
 <!-- 

--- a/BlazorIW.Client/Pages/FileList.razor
+++ b/BlazorIW.Client/Pages/FileList.razor
@@ -1,27 +1,30 @@
 @page "/files"
+@using Microsoft.Extensions.Localization
+@inject IStringLocalizer<FileList> L
+@inject LocalizationService Localization
 
-<PageTitle>File List</PageTitle>
+<PageTitle>@L["File List"]</PageTitle>
 
 @inject BlazorIW.Client.Services.FileService FileService
 
-<h1>Files under wwwroot</h1>
+<h1>@L["Files under wwwroot"]</h1>
 
 @if (files == null)
 {
-    <p>Loading...</p>
+    <p>@L["Loading..."]</p>
 }
 else if (!files.Any())
 {
-    <p>No files found.</p>
+    <p>@L["No files found."]</p>
 }
 else
 {
-    <button class="btn btn-primary mb-3" @onclick="StartAssessment" disabled="@isAssessing">Start Assessment</button>
+    <button class="btn btn-primary mb-3" @onclick="StartAssessment" disabled="@isAssessing">@L["Start Assessment"]</button>
     <table class="table">
         <thead>
             <tr>
-                <th>Path</th>
-                <th>Status</th>
+                <th>@L["Path"]</th>
+                <th>@L["Status"]</th>
             </tr>
         </thead>
         <tbody>
@@ -44,7 +47,7 @@ else
     {
         var fileData = await FileService.GetFilesAsync();
         files = fileData
-            .Select(f => new FileStatusInfo(f.Path, "Not checked"))
+            .Select(f => new FileStatusInfo(f.Path, L["Not checked"]))
             .ToList();
     }
 
@@ -59,10 +62,10 @@ else
 
         foreach (var file in files)
         {
-            file.Status = "Checking...";
+            file.Status = L["Checking..."]; 
             StateHasChanged();
             var ok = await FileService.IsFileAccessibleAsync(file.Path);
-            file.Status = ok ? "Accessible" : "Unavailable";
+            file.Status = ok ? L["Accessible"] : L["Unavailable"];
             StateHasChanged();
         }
 

--- a/BlazorIW.Client/Pages/Home.razor
+++ b/BlazorIW.Client/Pages/Home.razor
@@ -1,8 +1,11 @@
 ﻿@page "/"
 @rendermode InteractiveWebAssembly
+@using Microsoft.Extensions.Localization
+@inject IStringLocalizer<Home> L
+@inject LocalizationService Localization
 
-<PageTitle>Home</PageTitle>
+<PageTitle>@L["Home"]</PageTitle>
 
-<h1 id="homeTitle">Thank you coop</h1>
+<h1 id="homeTitle">@L["Thank you coop"]</h1>
 
 <BackgroundVideo/>

--- a/BlazorIW.Client/Pages/SelfInspection.razor
+++ b/BlazorIW.Client/Pages/SelfInspection.razor
@@ -1,13 +1,16 @@
 @page "/inspect"
 @rendermode InteractiveWebAssembly
+@using Microsoft.Extensions.Localization
+@inject IStringLocalizer<SelfInspection> L
+@inject LocalizationService Localization
 
-<PageTitle>Self Inspection</PageTitle>
+<PageTitle>@L["Self Inspection"]</PageTitle>
 
-<h1>Entity Framework Model</h1>
+<h1>@L["Entity Framework Model"]</h1>
 <div id="maindiv">
 @if (entities is null)
 {
-    <p>Loading...</p>
+    <p>@L["Loading..."]</p>
 }
 else
 {
@@ -18,8 +21,8 @@ else
         <table class="table table-bordered table-sm mb-3 w-auto">
             <thead class="table-primary">
                 <tr>
-                    <th>Property</th>
-                    <th>Type</th>
+                    <th>@L["Property"]</th>
+                    <th>@L["Type"]</th>
                 </tr>
             </thead>
             <tbody>
@@ -34,12 +37,12 @@ else
         </table>
         @if (entity.Navigations?.Count > 0)
         {
-            <h4>Relations</h4>
+            <h4>@L["Relations"]</h4>
             <table class="table table-bordered table-sm mb-4 w-auto">
                 <thead class="table-secondary">
                     <tr>
-                        <th>Navigation</th>
-                        <th>Target</th>
+                        <th>@L["Navigation"]</th>
+                        <th>@L["Target"]</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -55,7 +58,7 @@ else
         }
         @if (entity.Rows?.Count > 0)
         {
-            <h4>Top Rows</h4>
+            <h4>@L["Top Rows"]</h4>
             <table class="table table-bordered table-sm mb-4 w-auto">
                 <thead class="table-light">
                     <tr>

--- a/BlazorIW.Client/Pages/StorageDemo.razor
+++ b/BlazorIW.Client/Pages/StorageDemo.razor
@@ -1,29 +1,32 @@
 @page "/storage"
 @rendermode InteractiveWebAssembly
+@using Microsoft.Extensions.Localization
+@inject IStringLocalizer<StorageDemo> L
+@inject LocalizationService Localization
 
-<PageTitle>Storage Demo</PageTitle>
+<PageTitle>@L["Storage Demo"]</PageTitle>
 
 @inject BrowserStorageService Storage
 
-<h1>Browser Storage Demo</h1>
+<h1>@L["Browser Storage Demo"]</h1>
 
 <div class="mb-3">
-    <input class="form-control" placeholder="Enter value" @bind="inputValue" />
+    <input class="form-control" placeholder="@L["Enter value"]" @bind="inputValue" />
 </div>
 
 <div class="mb-3">
-    <button class="btn btn-primary me-1" @onclick="SaveLocalAsync">Save Local</button>
-    <button class="btn btn-secondary me-1" @onclick="LoadLocalAsync">Load Local</button>
-    <button class="btn btn-outline-danger me-1" @onclick="ClearLocalAsync">Clear Local</button>
+    <button class="btn btn-primary me-1" @onclick="SaveLocalAsync">@L["Save Local"]</button>
+    <button class="btn btn-secondary me-1" @onclick="LoadLocalAsync">@L["Load Local"]</button>
+    <button class="btn btn-outline-danger me-1" @onclick="ClearLocalAsync">@L["Clear Local"]</button>
 </div>
 
 <div class="mb-3">
-    <button class="btn btn-primary me-1" @onclick="SaveSessionAsync">Save Session</button>
-    <button class="btn btn-secondary me-1" @onclick="LoadSessionAsync">Load Session</button>
-    <button class="btn btn-outline-danger me-1" @onclick="ClearSessionAsync">Clear Session</button>
+    <button class="btn btn-primary me-1" @onclick="SaveSessionAsync">@L["Save Session"]</button>
+    <button class="btn btn-secondary me-1" @onclick="LoadSessionAsync">@L["Load Session"]</button>
+    <button class="btn btn-outline-danger me-1" @onclick="ClearSessionAsync">@L["Clear Session"]</button>
 </div>
 
-<p>Stored value: @storedValue</p>
+<p>@L["Stored value:"] @storedValue</p>
 
 @code {
     private string? inputValue;

--- a/BlazorIW.Client/Pages/Titles.razor
+++ b/BlazorIW.Client/Pages/Titles.razor
@@ -1,20 +1,23 @@
 @page "/titles"
+@using Microsoft.Extensions.Localization
+@inject IStringLocalizer<Titles> L
+@inject LocalizationService Localization
 
-<PageTitle>Titles</PageTitle>
+<PageTitle>@L["Titles"]</PageTitle>
 
 @inject HtmlContentService HtmlSvc
 @inject AuthenticationStateProvider AuthenticationStateProvider
 @using Microsoft.AspNetCore.Components.Authorization
 
-<h1>Titles</h1>
+<h1>@L["Titles"]</h1>
 
 @if (items == null)
 {
-    <p><em>Loading...</em></p>
+    <p><em>@L["Loading..."]</em></p>
 }
 else if (items.Count == 0)
 {
-    <p>No entries found.</p>
+    <p>@L["No entries found."]</p>
 }
 else
 {
@@ -45,22 +48,22 @@ else
                         <div class="btn-group mb-2" role="group">
                             @if (showFull)
                             {
-                                <button class="btn btn-sm btn-secondary" @onclick="() => ShowExcerpt(item.Id)">Show Excerpt</button>
+                                <button class="btn btn-sm btn-secondary" @onclick="() => ShowExcerpt(item.Id)">@L["Show Excerpt"]</button>
                             }
                             else
                             {
-                                <button class="btn btn-sm btn-secondary" @onclick="() => ShowFull(item.Id)">Show Full</button>
+                                <button class="btn btn-sm btn-secondary" @onclick="() => ShowFull(item.Id)">@L["Show Full"]</button>
                             }
-                            <button class="btn btn-sm btn-outline-secondary" @onclick="() => Collapse(item.Id)">Collapse</button>
+                            <button class="btn btn-sm btn-outline-secondary" @onclick="() => Collapse(item.Id)">@L["Collapse"]</button>
                         </div>
                         @if (isAuthenticated)
                         {
-                            <div class="mb-2">Status: @GetStatusValue(item)</div>
+                            <div class="mb-2">@L["Status"]: @L[GetStatusValue(item)]</div>
                             <AuthorizeView Roles="admin">
                                 <select class="form-select form-select-sm w-auto mb-2" value="@GetStatusValue(item)" @onchange="async e => await ChangeStatusAsync(item, e.Value?.ToString())">
-                                    <option value="Draft">Draft</option>
-                                    <option value="Review">Review</option>
-                                    <option value="Published">Published</option>
+                                    <option value="Draft">@L["Draft"]</option>
+                                    <option value="Review">@L["Review"]</option>
+                                    <option value="Published">@L["Published"]</option>
                                 </select>
                             </AuthorizeView>
                         }

--- a/BlazorIW.Client/Pages/WordPress.razor
+++ b/BlazorIW.Client/Pages/WordPress.razor
@@ -2,27 +2,30 @@
 @rendermode InteractiveWebAssembly
 @using System.Text.Json
 @using Microsoft.AspNetCore.Components
+@using Microsoft.Extensions.Localization
+@inject IStringLocalizer<WordPress> L
+@inject LocalizationService Localization
 
-<PageTitle>WordPress Posts</PageTitle>
+<PageTitle>@L["WordPress Posts"]</PageTitle>
 
 @inject WordPressService WordPressSvc
 @inject BrowserStorageService Storage
 @inject HtmlContentService HtmlSvc
 
-<h1>WordPress Posts</h1>
+<h1>@L["WordPress Posts"]</h1>
 
 <div class="mb-3">
-    <input class="form-control" placeholder="Enter base API URL" @bind="baseUrl" />
+    <input class="form-control" placeholder="@L["Enter base API URL"]" @bind="baseUrl" />
 </div>
-<button class="btn btn-primary mb-3" @onclick="LoadPosts">Fetch Posts</button>
+<button class="btn btn-primary mb-3" @onclick="LoadPosts">@L["Fetch Posts"]</button>
 <button class="btn btn-secondary mb-3 ms-2" @onclick="ToggleSummary" disabled="@(posts is null)">
-    @(showSummary ? "Show JSON" : "Show Summary")
+    @(showSummary ? L["Show JSON"] : L["Show Summary"])
 </button>
-<button class="btn btn-success mb-3 ms-2" @onclick="ImportPosts" disabled="@(posts is null)">Import Posts</button>
+<button class="btn btn-success mb-3 ms-2" @onclick="ImportPosts" disabled="@(posts is null)">@L["Import Posts"]</button>
 
 @if (isLoading)
 {
-    <p><em>Loading...</em></p>
+    <p><em>@L["Loading..."]</em></p>
 }
 else if (!string.IsNullOrEmpty(errorMessage))
 {
@@ -35,10 +38,10 @@ else if (posts != null)
         <table class="table">
             <thead>
                 <tr>
-                    <th>Date</th>
-                    <th>Title</th>
-                    <th>Excerpt</th>
-                    <th>Content</th>
+                    <th>@L["Date"]</th>
+                    <th>@L["Title"]</th>
+                    <th>@L["Excerpt"]</th>
+                    <th>@L["Content"]</th>
                 </tr>
             </thead>
             <tbody>
@@ -59,8 +62,8 @@ else if (posts != null)
         <table class="table">
             <thead>
                 <tr>
-                    <th>Exists</th>
-                    <th>Json</th>
+                    <th>@L["Exists"]</th>
+                    <th>@L["Json"]</th>
                 </tr>
             </thead>
             <tbody>
@@ -78,7 +81,7 @@ else if (posts != null)
                             else
                             {
                                 <span>✖</span>
-                                <button class="btn btn-sm btn-primary ms-2" @onclick="() => DownloadPost(p)">Download</button>
+                                <button class="btn btn-sm btn-primary ms-2" @onclick="() => DownloadPost(p)">@L["Download"]</button>
                             }
                         </td>
                         <td><pre>@json</pre></td>
@@ -143,7 +146,7 @@ else if (posts != null)
     {
         if (string.IsNullOrWhiteSpace(baseUrl))
         {
-            errorMessage = "Please enter a URL.";
+            errorMessage = L["Please enter a URL."];
             posts = null;
             return;
         }
@@ -157,7 +160,7 @@ else if (posts != null)
             posts = await WordPressSvc.FetchPostsAsync(baseUrl);
             if (posts.Count == 0)
             {
-                errorMessage = "No posts found.";
+                errorMessage = L["No posts found."];
             }
             await Storage.SetLocalStorageAsync(UrlKey, baseUrl);
             await Storage.SetLocalStorageAsync(PostsKey, postsJson ?? string.Empty);
@@ -190,7 +193,7 @@ else if (posts != null)
         {
             var added = await HtmlSvc.ImportPostsAsync(list);
             existingTitles = await HtmlSvc.GetTitlesAsync();
-            infoMessage = $"Imported {added} post(s).";
+            infoMessage = string.Format(L["Imported {0} post(s)."], added);
         }
         catch (Exception ex)
         {
@@ -210,7 +213,7 @@ else if (posts != null)
         {
             var added = await HtmlSvc.ImportPostsAsync(new[] { dto });
             existingTitles = await HtmlSvc.GetTitlesAsync();
-            infoMessage = $"Imported {added} post(s).";
+            infoMessage = string.Format(L["Imported {0} post(s)."], added);
         }
         catch (Exception ex)
         {

--- a/BlazorIW.Client/Resources/Pages/Auth.ja.resx
+++ b/BlazorIW.Client/Resources/Pages/Auth.ja.resx
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="Auth" xml:space="preserve">
+    <value>認証</value>
+  </data>
+  <data name="You are authenticated" xml:space="preserve">
+    <value>あなたは認証されています</value>
+  </data>
+  <data name="Hello" xml:space="preserve">
+    <value>こんにちは</value>
+  </data>
+</root>

--- a/BlazorIW.Client/Resources/Pages/Auth.resx
+++ b/BlazorIW.Client/Resources/Pages/Auth.resx
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="Auth" xml:space="preserve">
+    <value>Auth</value>
+  </data>
+  <data name="You are authenticated" xml:space="preserve">
+    <value>You are authenticated</value>
+  </data>
+  <data name="Hello" xml:space="preserve">
+    <value>Hello</value>
+  </data>
+</root>

--- a/BlazorIW.Client/Resources/Pages/Counter.ja.resx
+++ b/BlazorIW.Client/Resources/Pages/Counter.ja.resx
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="Counter" xml:space="preserve">
+    <value>カウンター</value>
+  </data>
+  <data name="Current count:" xml:space="preserve">
+    <value>現在の数:</value>
+  </data>
+  <data name="Click me" xml:space="preserve">
+    <value>クリックして</value>
+  </data>
+</root>

--- a/BlazorIW.Client/Resources/Pages/Counter.resx
+++ b/BlazorIW.Client/Resources/Pages/Counter.resx
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="Counter" xml:space="preserve">
+    <value>Counter</value>
+  </data>
+  <data name="Current count:" xml:space="preserve">
+    <value>Current count:</value>
+  </data>
+  <data name="Click me" xml:space="preserve">
+    <value>Click me</value>
+  </data>
+</root>

--- a/BlazorIW.Client/Resources/Pages/D3Demo.ja.resx
+++ b/BlazorIW.Client/Resources/Pages/D3Demo.ja.resx
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="D3 Demo" xml:space="preserve">
+    <value>D3 デモ</value>
+  </data>
+  <data name="View mode" xml:space="preserve">
+    <value>表示モード</value>
+  </data>
+  <data name="List" xml:space="preserve">
+    <value>リスト</value>
+  </data>
+  <data name="Hex Map" xml:space="preserve">
+    <value>ヘックスマップ</value>
+  </data>
+</root>

--- a/BlazorIW.Client/Resources/Pages/D3Demo.resx
+++ b/BlazorIW.Client/Resources/Pages/D3Demo.resx
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="D3 Demo" xml:space="preserve">
+    <value>D3 Demo</value>
+  </data>
+  <data name="View mode" xml:space="preserve">
+    <value>View mode</value>
+  </data>
+  <data name="List" xml:space="preserve">
+    <value>List</value>
+  </data>
+  <data name="Hex Map" xml:space="preserve">
+    <value>Hex Map</value>
+  </data>
+</root>

--- a/BlazorIW.Client/Resources/Pages/FileList.ja.resx
+++ b/BlazorIW.Client/Resources/Pages/FileList.ja.resx
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="File List" xml:space="preserve">
+    <value>ファイル一覧</value>
+  </data>
+  <data name="Files under wwwroot" xml:space="preserve">
+    <value>wwwrootのファイル</value>
+  </data>
+  <data name="Loading..." xml:space="preserve">
+    <value>読み込み中...</value>
+  </data>
+  <data name="No files found." xml:space="preserve">
+    <value>ファイルが見つかりません。</value>
+  </data>
+  <data name="Start Assessment" xml:space="preserve">
+    <value>検査開始</value>
+  </data>
+  <data name="Path" xml:space="preserve">
+    <value>パス</value>
+  </data>
+  <data name="Status" xml:space="preserve">
+    <value>状態</value>
+  </data>
+  <data name="Not checked" xml:space="preserve">
+    <value>未確認</value>
+  </data>
+  <data name="Checking..." xml:space="preserve">
+    <value>確認中...</value>
+  </data>
+  <data name="Accessible" xml:space="preserve">
+    <value>アクセス可能</value>
+  </data>
+  <data name="Unavailable" xml:space="preserve">
+    <value>利用不可</value>
+  </data>
+</root>

--- a/BlazorIW.Client/Resources/Pages/FileList.resx
+++ b/BlazorIW.Client/Resources/Pages/FileList.resx
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="File List" xml:space="preserve">
+    <value>File List</value>
+  </data>
+  <data name="Files under wwwroot" xml:space="preserve">
+    <value>Files under wwwroot</value>
+  </data>
+  <data name="Loading..." xml:space="preserve">
+    <value>Loading...</value>
+  </data>
+  <data name="No files found." xml:space="preserve">
+    <value>No files found.</value>
+  </data>
+  <data name="Start Assessment" xml:space="preserve">
+    <value>Start Assessment</value>
+  </data>
+  <data name="Path" xml:space="preserve">
+    <value>Path</value>
+  </data>
+  <data name="Status" xml:space="preserve">
+    <value>Status</value>
+  </data>
+  <data name="Not checked" xml:space="preserve">
+    <value>Not checked</value>
+  </data>
+  <data name="Checking..." xml:space="preserve">
+    <value>Checking...</value>
+  </data>
+  <data name="Accessible" xml:space="preserve">
+    <value>Accessible</value>
+  </data>
+  <data name="Unavailable" xml:space="preserve">
+    <value>Unavailable</value>
+  </data>
+</root>

--- a/BlazorIW.Client/Resources/Pages/Home.ja.resx
+++ b/BlazorIW.Client/Resources/Pages/Home.ja.resx
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="Home" xml:space="preserve">
+    <value>ホーム</value>
+  </data>
+  <data name="Thank you coop" xml:space="preserve">
+    <value>ありがとう協同組合</value>
+  </data>
+</root>

--- a/BlazorIW.Client/Resources/Pages/Home.resx
+++ b/BlazorIW.Client/Resources/Pages/Home.resx
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="Home" xml:space="preserve">
+    <value>Home</value>
+  </data>
+  <data name="Thank you coop" xml:space="preserve">
+    <value>Thank you coop</value>
+  </data>
+</root>

--- a/BlazorIW.Client/Resources/Pages/SelfInspection.ja.resx
+++ b/BlazorIW.Client/Resources/Pages/SelfInspection.ja.resx
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="Self Inspection" xml:space="preserve">
+    <value>自己検査</value>
+  </data>
+  <data name="Entity Framework Model" xml:space="preserve">
+    <value>Entity Framework モデル</value>
+  </data>
+  <data name="Loading..." xml:space="preserve">
+    <value>読み込み中...</value>
+  </data>
+  <data name="Property" xml:space="preserve">
+    <value>プロパティ</value>
+  </data>
+  <data name="Type" xml:space="preserve">
+    <value>型</value>
+  </data>
+  <data name="Relations" xml:space="preserve">
+    <value>リレーション</value>
+  </data>
+  <data name="Navigation" xml:space="preserve">
+    <value>ナビゲーション</value>
+  </data>
+  <data name="Target" xml:space="preserve">
+    <value>ターゲット</value>
+  </data>
+  <data name="Top Rows" xml:space="preserve">
+    <value>上位行</value>
+  </data>
+</root>

--- a/BlazorIW.Client/Resources/Pages/SelfInspection.resx
+++ b/BlazorIW.Client/Resources/Pages/SelfInspection.resx
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="Self Inspection" xml:space="preserve">
+    <value>Self Inspection</value>
+  </data>
+  <data name="Entity Framework Model" xml:space="preserve">
+    <value>Entity Framework Model</value>
+  </data>
+  <data name="Loading..." xml:space="preserve">
+    <value>Loading...</value>
+  </data>
+  <data name="Property" xml:space="preserve">
+    <value>Property</value>
+  </data>
+  <data name="Type" xml:space="preserve">
+    <value>Type</value>
+  </data>
+  <data name="Relations" xml:space="preserve">
+    <value>Relations</value>
+  </data>
+  <data name="Navigation" xml:space="preserve">
+    <value>Navigation</value>
+  </data>
+  <data name="Target" xml:space="preserve">
+    <value>Target</value>
+  </data>
+  <data name="Top Rows" xml:space="preserve">
+    <value>Top Rows</value>
+  </data>
+</root>

--- a/BlazorIW.Client/Resources/Pages/StorageDemo.ja.resx
+++ b/BlazorIW.Client/Resources/Pages/StorageDemo.ja.resx
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="Storage Demo" xml:space="preserve">
+    <value>ストレージデモ</value>
+  </data>
+  <data name="Browser Storage Demo" xml:space="preserve">
+    <value>ブラウザストレージデモ</value>
+  </data>
+  <data name="Enter value" xml:space="preserve">
+    <value>値を入力</value>
+  </data>
+  <data name="Save Local" xml:space="preserve">
+    <value>ローカル保存</value>
+  </data>
+  <data name="Load Local" xml:space="preserve">
+    <value>ローカル読み込み</value>
+  </data>
+  <data name="Clear Local" xml:space="preserve">
+    <value>ローカル削除</value>
+  </data>
+  <data name="Save Session" xml:space="preserve">
+    <value>セッション保存</value>
+  </data>
+  <data name="Load Session" xml:space="preserve">
+    <value>セッション読み込み</value>
+  </data>
+  <data name="Clear Session" xml:space="preserve">
+    <value>セッション削除</value>
+  </data>
+  <data name="Stored value:" xml:space="preserve">
+    <value>保存された値:</value>
+  </data>
+</root>

--- a/BlazorIW.Client/Resources/Pages/StorageDemo.resx
+++ b/BlazorIW.Client/Resources/Pages/StorageDemo.resx
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="Storage Demo" xml:space="preserve">
+    <value>Storage Demo</value>
+  </data>
+  <data name="Browser Storage Demo" xml:space="preserve">
+    <value>Browser Storage Demo</value>
+  </data>
+  <data name="Enter value" xml:space="preserve">
+    <value>Enter value</value>
+  </data>
+  <data name="Save Local" xml:space="preserve">
+    <value>Save Local</value>
+  </data>
+  <data name="Load Local" xml:space="preserve">
+    <value>Load Local</value>
+  </data>
+  <data name="Clear Local" xml:space="preserve">
+    <value>Clear Local</value>
+  </data>
+  <data name="Save Session" xml:space="preserve">
+    <value>Save Session</value>
+  </data>
+  <data name="Load Session" xml:space="preserve">
+    <value>Load Session</value>
+  </data>
+  <data name="Clear Session" xml:space="preserve">
+    <value>Clear Session</value>
+  </data>
+  <data name="Stored value:" xml:space="preserve">
+    <value>Stored value:</value>
+  </data>
+</root>

--- a/BlazorIW.Client/Resources/Pages/Titles.ja.resx
+++ b/BlazorIW.Client/Resources/Pages/Titles.ja.resx
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="Titles" xml:space="preserve">
+    <value>タイトル</value>
+  </data>
+  <data name="Loading..." xml:space="preserve">
+    <value>読み込み中...</value>
+  </data>
+  <data name="No entries found." xml:space="preserve">
+    <value>エントリがありません。</value>
+  </data>
+  <data name="Show Excerpt" xml:space="preserve">
+    <value>抜粋を表示</value>
+  </data>
+  <data name="Show Full" xml:space="preserve">
+    <value>全文を表示</value>
+  </data>
+  <data name="Collapse" xml:space="preserve">
+    <value>折りたたむ</value>
+  </data>
+  <data name="Status" xml:space="preserve">
+    <value>ステータス</value>
+  </data>
+  <data name="Draft" xml:space="preserve">
+    <value>下書き</value>
+  </data>
+  <data name="Review" xml:space="preserve">
+    <value>レビュー</value>
+  </data>
+  <data name="Published" xml:space="preserve">
+    <value>公開済み</value>
+  </data>
+</root>

--- a/BlazorIW.Client/Resources/Pages/Titles.resx
+++ b/BlazorIW.Client/Resources/Pages/Titles.resx
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="Titles" xml:space="preserve">
+    <value>Titles</value>
+  </data>
+  <data name="Loading..." xml:space="preserve">
+    <value>Loading...</value>
+  </data>
+  <data name="No entries found." xml:space="preserve">
+    <value>No entries found.</value>
+  </data>
+  <data name="Show Excerpt" xml:space="preserve">
+    <value>Show Excerpt</value>
+  </data>
+  <data name="Show Full" xml:space="preserve">
+    <value>Show Full</value>
+  </data>
+  <data name="Collapse" xml:space="preserve">
+    <value>Collapse</value>
+  </data>
+  <data name="Status" xml:space="preserve">
+    <value>Status</value>
+  </data>
+  <data name="Draft" xml:space="preserve">
+    <value>Draft</value>
+  </data>
+  <data name="Review" xml:space="preserve">
+    <value>Review</value>
+  </data>
+  <data name="Published" xml:space="preserve">
+    <value>Published</value>
+  </data>
+</root>

--- a/BlazorIW.Client/Resources/Pages/WordPress.ja.resx
+++ b/BlazorIW.Client/Resources/Pages/WordPress.ja.resx
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="WordPress Posts" xml:space="preserve">
+    <value>WordPress 投稿</value>
+  </data>
+  <data name="Enter base API URL" xml:space="preserve">
+    <value>API 基本URLを入力</value>
+  </data>
+  <data name="Fetch Posts" xml:space="preserve">
+    <value>投稿を取得</value>
+  </data>
+  <data name="Show JSON" xml:space="preserve">
+    <value>JSONを表示</value>
+  </data>
+  <data name="Show Summary" xml:space="preserve">
+    <value>概要を表示</value>
+  </data>
+  <data name="Import Posts" xml:space="preserve">
+    <value>投稿をインポート</value>
+  </data>
+  <data name="Loading..." xml:space="preserve">
+    <value>読み込み中...</value>
+  </data>
+  <data name="Please enter a URL." xml:space="preserve">
+    <value>URLを入力してください。</value>
+  </data>
+  <data name="No posts found." xml:space="preserve">
+    <value>投稿が見つかりません。</value>
+  </data>
+  <data name="Date" xml:space="preserve">
+    <value>日付</value>
+  </data>
+  <data name="Title" xml:space="preserve">
+    <value>タイトル</value>
+  </data>
+  <data name="Excerpt" xml:space="preserve">
+    <value>抜粋</value>
+  </data>
+  <data name="Content" xml:space="preserve">
+    <value>コンテンツ</value>
+  </data>
+  <data name="Exists" xml:space="preserve">
+    <value>存在</value>
+  </data>
+  <data name="Json" xml:space="preserve">
+    <value>JSON</value>
+  </data>
+  <data name="Download" xml:space="preserve">
+    <value>ダウンロード</value>
+  </data>
+  <data name="Imported {0} post(s)." xml:space="preserve">
+    <value>{0} 件の投稿をインポートしました。</value>
+  </data>
+</root>

--- a/BlazorIW.Client/Resources/Pages/WordPress.resx
+++ b/BlazorIW.Client/Resources/Pages/WordPress.resx
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="WordPress Posts" xml:space="preserve">
+    <value>WordPress Posts</value>
+  </data>
+  <data name="Enter base API URL" xml:space="preserve">
+    <value>Enter base API URL</value>
+  </data>
+  <data name="Fetch Posts" xml:space="preserve">
+    <value>Fetch Posts</value>
+  </data>
+  <data name="Show JSON" xml:space="preserve">
+    <value>Show JSON</value>
+  </data>
+  <data name="Show Summary" xml:space="preserve">
+    <value>Show Summary</value>
+  </data>
+  <data name="Import Posts" xml:space="preserve">
+    <value>Import Posts</value>
+  </data>
+  <data name="Loading..." xml:space="preserve">
+    <value>Loading...</value>
+  </data>
+  <data name="Please enter a URL." xml:space="preserve">
+    <value>Please enter a URL.</value>
+  </data>
+  <data name="No posts found." xml:space="preserve">
+    <value>No posts found.</value>
+  </data>
+  <data name="Date" xml:space="preserve">
+    <value>Date</value>
+  </data>
+  <data name="Title" xml:space="preserve">
+    <value>Title</value>
+  </data>
+  <data name="Excerpt" xml:space="preserve">
+    <value>Excerpt</value>
+  </data>
+  <data name="Content" xml:space="preserve">
+    <value>Content</value>
+  </data>
+  <data name="Exists" xml:space="preserve">
+    <value>Exists</value>
+  </data>
+  <data name="Json" xml:space="preserve">
+    <value>Json</value>
+  </data>
+  <data name="Download" xml:space="preserve">
+    <value>Download</value>
+  </data>
+  <data name="Imported {0} post(s)." xml:space="preserve">
+    <value>Imported {0} post(s).</value>
+  </data>
+</root>


### PR DESCRIPTION
## Summary
- localize Home, Counter, Auth, D3Demo, FileList, SelfInspection, StorageDemo, Titles and WordPress pages
- add matching resource files in English and Japanese

## Testing
- `bash scripts/test.sh` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848f6b52f288322916e1349142a3c48