### PR TITLE
Sync culture cookie with client selection

### DIFF
--- a/BlazorIW.Client/Services/LocalizationService.cs
+++ b/BlazorIW.Client/Services/LocalizationService.cs
@@ -1,5 +1,7 @@
 using System.Globalization;
 using Microsoft.JSInterop;
+using System.Net.Http;
+using System.Net.Http.Json;
 
 namespace BlazorIW.Client.Services;
 
@@ -7,13 +9,15 @@ public class LocalizationService
 {
     private readonly IJSRuntime _js;
     private readonly BrowserStorageService _storage;
+    private readonly HttpClient _http;
     private bool _loaded;
     public event Action? OnChange;
 
-    public LocalizationService(IJSRuntime js, BrowserStorageService storage)
+    public LocalizationService(IJSRuntime js, BrowserStorageService storage, HttpClient http)
     {
         _js = js;
         _storage = storage;
+        _http = http;
         CurrentCulture = CultureInfo.CurrentCulture;
     }
 
@@ -48,6 +52,7 @@ public class LocalizationService
         }
 
         SetThreadCulture(culture);
+        await _http.GetAsync($"api/set-culture?culture={Uri.EscapeDataString(culture)}");
         _loaded = true;
         OnChange?.Invoke();
     }
@@ -55,6 +60,7 @@ public class LocalizationService
     public async Task SetCultureAsync(string culture)
     {
         await _storage.SetLocalStorageAsync("blazorCulture", culture);
+        await _http.GetAsync($"api/set-culture?culture={Uri.EscapeDataString(culture)}");
         SetThreadCulture(culture);
         OnChange?.Invoke();
     }

--- a/BlazorIW/Program.cs
+++ b/BlazorIW/Program.cs
@@ -100,6 +100,7 @@ var localizationOptions = new RequestLocalizationOptions()
     .SetDefaultCulture("en")
     .AddSupportedCultures(supportedCultures)
     .AddSupportedUICultures(supportedCultures);
+localizationOptions.RequestCultureProviders.Insert(0, new CookieRequestCultureProvider());
 app.UseRequestLocalization(localizationOptions);
 
 // Serve files from wwwroot for environments where MapStaticAssets might not
@@ -109,6 +110,15 @@ app.UseStaticFiles();
 app.UseAntiforgery();
 
 app.MapStaticAssets();
+
+
+app.MapGet("/api/set-culture", (HttpContext context, string culture) =>
+{
+    context.Response.Cookies.Append(
+        CookieRequestCultureProvider.DefaultCookieName,
+        CookieRequestCultureProvider.MakeCookieValue(new RequestCulture(culture)));
+    return Results.Ok();
+});
 
 
 


### PR DESCRIPTION
## Summary
- add a minimal API endpoint to set the culture cookie
- insert `CookieRequestCultureProvider` so the culture cookie is honored
- update `LocalizationService` to call the server when the culture is loaded or changed

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6849e6a1e11c8322a22a6edfdaa20aab