### PR TITLE
Early background video load

### DIFF
--- a/BlazorIW.Client/Layout/MainLayout.razor
+++ b/BlazorIW.Client/Layout/MainLayout.razor
@@ -1,4 +1,7 @@
 ﻿@inherits LayoutComponentBase
+@inject NavigationManager NavManager
+@inject IJSRuntime JS
+@implements IDisposable
 
 <div class="page">
     <div class="sidebar">
@@ -21,3 +24,34 @@
     <a href="." class="reload">Reload</a>
     <span class="dismiss">🗙</span>
 </div>
+
+@code {
+    private bool _first = true;
+
+    protected override void OnInitialized()
+    {
+        NavManager.LocationChanged += OnLocationChanged;
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (_first)
+        {
+            _first = false;
+            bool isHome = NavManager.ToBaseRelativePath(NavManager.Uri) == string.Empty;
+            await JS.InvokeVoidAsync("setHomeVideoVisible", isHome);
+        }
+    }
+
+    private async void OnLocationChanged(object? sender, LocationChangedEventArgs e)
+    {
+        bool isHome = NavManager.ToBaseRelativePath(e.Location) == string.Empty;
+        await JS.InvokeVoidAsync("setHomeVideoVisible", isHome);
+    }
+
+    public void Dispose()
+    {
+        NavManager.LocationChanged -= OnLocationChanged;
+    }
+}
+

--- a/BlazorIW.Client/Pages/BackgroundVideo.razor
+++ b/BlazorIW.Client/Pages/BackgroundVideo.razor
@@ -1,11 +1,4 @@
-@if (RendererInfo.IsInteractive){
-
-<video id="background-video-1" class="background-video" autoplay muted preload="auto" playsinline></video>
-<video id="background-video-2" class="background-video" autoplay muted preload="auto" playsinline></video>
-@* <div id="video-info"></div> *@
-
-<script src="js/background-video.js"></script>
-
-}else{
-    @* show still image from pexel of video-1 in EXACTLY the same dimension.  The image should be kept as cached file as part of the data seeding *@
+@if (!RendererInfo.IsInteractive)
+{
+    <div style="width:100%;height:30vh;background-color:black"></div>
 }

--- a/BlazorIW/Components/App.razor
+++ b/BlazorIW/Components/App.razor
@@ -8,12 +8,56 @@
     <link rel="stylesheet" href="@Assets["lib/bootstrap/dist/css/bootstrap.min.css"]" />
     <link rel="stylesheet" href="@Assets["app.css"]" />
     <link rel="stylesheet" href="@Assets["BlazorIW.styles.css"]" />
+    <style>
+        .background-video {
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 10px;
+            height: 30vh;
+            width: 100%;
+            object-fit: cover;
+            pointer-events: none;
+            z-index: -1;
+            background-color: black;
+            opacity: 0;
+            mask-image: linear-gradient(to right, rgba(255, 255, 255, 0.1) 0px, rgba(255, 255, 255, 0.1) 150px, rgba(255, 255, 255, 1) 350px);
+            -webkit-mask-image: linear-gradient(to right, rgba(255, 255, 255, 0.1) 0px, rgba(255, 255, 255, 0.1) 150px, rgba(255, 255, 255, 1) 350px);
+        }
+        .hide-video #background-video-1,
+        .hide-video #background-video-2 {
+            display: none;
+        }
+    </style>
+    <script>
+        if (window.location.pathname !== '/' && window.location.pathname !== '/index.html') {
+            document.documentElement.classList.add('hide-video');
+        }
+        window.setHomeVideoVisible = function (show) {
+            const v1 = document.getElementById('background-video-1');
+            const v2 = document.getElementById('background-video-2');
+            if (!v1 || !v2) return;
+            if (show) {
+                document.documentElement.classList.remove('hide-video');
+                v1.play();
+                v2.play();
+            } else {
+                document.documentElement.classList.add('hide-video');
+                v1.pause();
+                v2.pause();
+            }
+        };
+    </script>
     <ImportMap />
     <link rel="icon" type="image/png" href="favicon.png" />
     <HeadOutlet @rendermode="PageRenderMode" />
 </head>
 
 <body>
+    <video id="background-video-1" class="background-video" autoplay muted preload="auto" playsinline></video>
+    <video id="background-video-2" class="background-video" autoplay muted preload="auto" playsinline></video>
+    <script src='@Assets["js/background-video.js"]' defer></script>
     <Routes @rendermode="PageRenderMode" />
 
     <script src="@Assets["libman/d3.min.js"]"></script>

--- a/BlazorIW/wwwroot/js/background-video.js
+++ b/BlazorIW/wwwroot/js/background-video.js
@@ -1,4 +1,8 @@
 (async function () {
+  if (window.backgroundVideoInitialized) {
+    return;
+  }
+  window.backgroundVideoInitialized = true;
   const videos = [
     document.getElementById('background-video-1'),
     document.getElementById('background-video-2'),
@@ -54,12 +58,15 @@
         const info = await getVideoInfo(entry.api);
         if (info && info.url) {
           entry.url = info.url;
+          if (idx === 0 && info.poster) {
+            videos[0].setAttribute('poster', info.poster);
+          }
           return entry.url;
         } else {
-          console.warn(`[getCachedVideoUrl] No "url" field in JSON for attempt ${i+1}`);
+          console.warn(`[getCachedVideoUrl] No "url" field in JSON for attempt ${i + 1}`);
         }
       } catch (e) {
-        console.warn(`[getCachedVideoUrl] Error on attempt ${i+1} for idx ${idx}:`, e);
+        console.warn(`[getCachedVideoUrl] Error on attempt ${i + 1} for idx ${idx}:`, e);
         if (i === attempts - 1) throw e;
       }
     }


### PR DESCRIPTION
## Summary
- bootstrap background video and control visibility in `App.razor`
- hide/show video with JS interop in `MainLayout`
- strip logic from `BackgroundVideo` component
- guard background-video script from running twice and set poster image

## Testing
- `./scripts/test.sh` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684c048f866c8322b1d01ea000d75ea7