### PR TITLE
Remove black background from video placeholder

### DIFF
--- a/BlazorIW.Client/Pages/BackgroundVideo.razor
+++ b/BlazorIW.Client/Pages/BackgroundVideo.razor
@@ -1,4 +1,4 @@
 @if (!RendererInfo.IsInteractive)
 {
-    <div style="width:100%;height:30vh;background-color:black"></div>
+    <div style="width:100%;height:30vh;"></div>
 }

--- a/BlazorIW/Components/App.razor
+++ b/BlazorIW/Components/App.razor
@@ -20,7 +20,6 @@
             object-fit: cover;
             pointer-events: none;
             z-index: -1;
-            background-color: black;
             opacity: 0;
             mask-image: linear-gradient(to right, rgba(255, 255, 255, 0.1) 0px, rgba(255, 255, 255, 0.1) 150px, rgba(255, 255, 255, 1) 350px);
             -webkit-mask-image: linear-gradient(to right, rgba(255, 255, 255, 0.1) 0px, rgba(255, 255, 255, 0.1) 150px, rgba(255, 255, 255, 1) 350px);


### PR DESCRIPTION
## Summary
- clean up placeholder styling for `BackgroundVideo`
- drop `background-color` from `App` layout video style

## Testing
- `scripts/test.sh` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c6dbb48bc8322806403d9f1a048ee